### PR TITLE
[ StickerPack ] 선택된 스티커 데이터 라우트 이동

### DIFF
--- a/src/StickerPack/components/StickerList/index.tsx
+++ b/src/StickerPack/components/StickerList/index.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 
 import useGetStickerPack from '../../hooks/useGetStickerPack';
-import { stickerPackType } from '../../type/stickerPackType';
+import { stickerPackType, stickerType } from '../../type/stickerPackType';
 import * as S from './StickerList.style';
 
 interface StickerListProps {

--- a/src/StickerPack/components/StickerList/index.tsx
+++ b/src/StickerPack/components/StickerList/index.tsx
@@ -5,13 +5,12 @@ import { stickerPackType, stickerType } from '../../type/stickerPackType';
 import * as S from './StickerList.style';
 
 interface StickerListProps {
-  isSelectedId: number | null;
-  handleStickerClick: (stickerId: number) => void;
+  selectedStickerData: stickerType;
+  handleStickerClick: (newId: number, newImage: string) => void;
 }
 
 function StickerList(props: StickerListProps) {
-  const { isSelectedId, handleStickerClick } = props;
-  //TODO 임시 값 수정
+  const { selectedStickerData, handleStickerClick } = props;
   const { stickerPack } = useGetStickerPack(1);
 
   return (

--- a/src/StickerPack/components/StickerList/index.tsx
+++ b/src/StickerPack/components/StickerList/index.tsx
@@ -24,8 +24,12 @@ function StickerList(props: StickerListProps) {
                 <S.ImageWrapper
                   type="button"
                   key={sticker.stickerId}
-                  onClick={() => handleStickerClick(sticker.stickerId)}
-                  isSelected={sticker.stickerId === isSelectedId}
+                  onClick={() =>
+                    handleStickerClick(sticker.stickerId, sticker.stickerImage)
+                  }
+                  isSelected={
+                    sticker.stickerId === selectedStickerData.stickerId
+                  }
                 >
                   <S.ImageComponent
                     src={sticker.stickerImage}

--- a/src/StickerPack/page/StickerPack/StickerPack.style.ts
+++ b/src/StickerPack/page/StickerPack/StickerPack.style.ts
@@ -3,13 +3,13 @@ import styled from '@emotion/styled';
 export const Body = styled.article`
   padding: 0 1.64rem;
   padding-bottom: 5rem;
+  margin-top: 5.5rem;
 
   background-color: ${({ theme }) => theme.colors.background};
 `;
 
 export const Wrapper = styled.section`
   display: flex;
-  justify-content: center;
   align-items: center;
   flex-direction: column;
 

--- a/src/StickerPack/page/StickerPack/StickerPack.style.ts
+++ b/src/StickerPack/page/StickerPack/StickerPack.style.ts
@@ -16,3 +16,11 @@ export const Wrapper = styled.section`
   width: 100vw;
   height: 100dvh;
 `;
+
+export const ButtonWrapper = styled.div`
+  position: fixed;
+  bottom: 2rem;
+
+  width: 100%;
+  padding: 0 2.5rem;
+`;

--- a/src/StickerPack/page/StickerPack/StickerPack.style.ts
+++ b/src/StickerPack/page/StickerPack/StickerPack.style.ts
@@ -1,6 +1,10 @@
 import styled from '@emotion/styled';
 
 export const Body = styled.article`
+  display: flex;
+  justify-content: center;
+
+  width: 100%;
   padding: 0 1.64rem;
   padding-bottom: 5rem;
   margin-top: 5.5rem;

--- a/src/StickerPack/page/StickerPack/index.tsx
+++ b/src/StickerPack/page/StickerPack/index.tsx
@@ -37,6 +37,8 @@ function StickerPack() {
           selectedStickerData={selectedStickerData}
           handleStickerClick={handleStickerClick}
         />
+      </S.Body>
+      <S.ButtonWrapper>
         <Button
           variant="choose"
           disabled={selectedStickerData.stickerImage === ''}
@@ -44,7 +46,7 @@ function StickerPack() {
         >
           선택 완료
         </Button>
-      </S.Body>
+      </S.ButtonWrapper>
     </S.Wrapper>
   );
 }

--- a/src/StickerPack/page/StickerPack/index.tsx
+++ b/src/StickerPack/page/StickerPack/index.tsx
@@ -30,7 +30,7 @@ function StickerPack() {
   };
 
   return (
-    <>
+    <S.Wrapper>
       <Header headerTitle="스티커팩" />
       <S.Body>
         <StickerList
@@ -45,7 +45,7 @@ function StickerPack() {
           선택 완료
         </Button>
       </S.Body>
-    </>
+    </S.Wrapper>
   );
 }
 

--- a/src/StickerPack/page/StickerPack/index.tsx
+++ b/src/StickerPack/page/StickerPack/index.tsx
@@ -15,9 +15,14 @@ function StickerPack() {
     stickerImage: '',
   });
 
-  const handleStickerClick = (stickerId: number) => {
-    setIsSelectedId(stickerId);
+  const handleStickerClick = (newId: number, newImage: string) => {
+    setSelectedStickerData((prevState) => ({
+      ...prevState,
+      stickerId: newId,
+      stickerImage: newImage,
+    }));
   };
+
 
   const handleClickDone = () => {
     alert(`${isSelectedId}`);

--- a/src/StickerPack/page/StickerPack/index.tsx
+++ b/src/StickerPack/page/StickerPack/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 // component
 import Button from '../../../components/common/Button/index.tsx';
@@ -10,6 +11,7 @@ import { stickerType } from '../../type/stickerPackType.ts';
 import * as S from './StickerPack.style.ts';
 
 function StickerPack() {
+  const navigate = useNavigate();
   const [selectedStickerData, setSelectedStickerData] = useState<stickerType>({
     stickerId: 0,
     stickerImage: '',
@@ -23,9 +25,8 @@ function StickerPack() {
     }));
   };
 
-
   const handleClickDone = () => {
-    alert(`${isSelectedId}`);
+    navigate('/sticker-attach', { state: { sticker: selectedStickerData } });
   };
 
   return (

--- a/src/StickerPack/page/StickerPack/index.tsx
+++ b/src/StickerPack/page/StickerPack/index.tsx
@@ -10,7 +10,10 @@ import { stickerType } from '../../type/stickerPackType.ts';
 import * as S from './StickerPack.style.ts';
 
 function StickerPack() {
-  const [isSelectedId, setIsSelectedId] = useState<number | null>(null);
+  const [selectedStickerData, setSelectedStickerData] = useState<stickerType>({
+    stickerId: 0,
+    stickerImage: '',
+  });
 
   const handleStickerClick = (stickerId: number) => {
     setIsSelectedId(stickerId);
@@ -25,12 +28,12 @@ function StickerPack() {
       <Header headerTitle="스티커팩" />
       <S.Body>
         <StickerList
-          isSelectedId={isSelectedId}
+          selectedStickerData={selectedStickerData}
           handleStickerClick={handleStickerClick}
         />
         <Button
           variant="choose"
-          disabled={isSelectedId == null}
+          disabled={selectedStickerData.stickerImage === ''}
           onClick={handleClickDone}
         >
           선택 완료

--- a/src/StickerPack/page/StickerPack/index.tsx
+++ b/src/StickerPack/page/StickerPack/index.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import Button from '../../../components/common/Button/index.tsx';
 import Header from '../../../components/common/Header/index.tsx';
 import StickerList from '../../components/StickerList/index.tsx';
+// type
+import { stickerType } from '../../type/stickerPackType.ts';
 // style
 import * as S from './StickerPack.style.ts';
 

--- a/src/StickerPack/type/stickerPackType.ts
+++ b/src/StickerPack/type/stickerPackType.ts
@@ -1,9 +1,9 @@
 export interface stickerPackType {
   stickerCategory: string;
-  stickerList: [
-    {
-      stickerId: number;
-      stickerImage: string;
-    },
-  ];
+  stickerList: stickerType[];
+}
+
+export interface stickerType {
+  stickerId: number;
+  stickerImage: string;
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #30 

## ✅ 작업 내용

- [x] 선택된 스티커의 정보를 라우터로 이동 시켜줌
- [x] 스티커의 상태 값 변경 해줌
