### PR TITLE
[ CreateNote] 레큐 노트 내부 기능 구현

### DIFF
--- a/src/LecueNote/components/CreateNote/CreateNote.style.ts
+++ b/src/LecueNote/components/CreateNote/CreateNote.style.ts
@@ -2,10 +2,9 @@ import styled from '@emotion/styled';
 
 export const Wrapper = styled.section`
   display: flex;
+  gap: 3.2rem;
   flex-direction: column;
 
   width: 100%;
   margin: 7.8rem 0 3.3rem;
-
-  gap: 3.2rem;
 `;

--- a/src/LecueNote/components/CreateNote/index.tsx
+++ b/src/LecueNote/components/CreateNote/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+
 import {
   BG_COLOR_CHART,
   CATEGORY,
@@ -31,7 +32,7 @@ function CreateNote() {
 
   return (
     <S.Wrapper>
-      <WriteNote clickedBgColor={clickedBgColor}/>
+      <WriteNote clickedBgColor={clickedBgColor} />
       <SelectColor
         clickedCategory={clickedCategory}
         clickedTextColor={clickedTextColor}

--- a/src/LecueNote/components/CreateNote/index.tsx
+++ b/src/LecueNote/components/CreateNote/index.tsx
@@ -32,7 +32,10 @@ function CreateNote() {
 
   return (
     <S.Wrapper>
-      <WriteNote clickedBgColor={clickedBgColor} />
+      <WriteNote
+        clickedBgColor={clickedBgColor}
+        clickedTextColor={clickedTextColor}
+      />
       <SelectColor
         clickedCategory={clickedCategory}
         clickedTextColor={clickedTextColor}

--- a/src/LecueNote/components/CreateNote/index.tsx
+++ b/src/LecueNote/components/CreateNote/index.tsx
@@ -14,6 +14,7 @@ function CreateNote({ contents, handleChangeFn }: CreateNoteProps) {
   const [clickedCategory, setclickedCategory] = useState(CATEGORY[0]);
   const [clickedTextColor, setClickedTextColor] = useState(TEXT_COLOR_CHART[0]);
   const [clickedBgColor, setclickedBgColor] = useState(BG_COLOR_CHART[0]);
+  const [isIconClicked, setIsIconClicked] = useState(false);
 
   const handleClickCategory = (
     e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
@@ -28,23 +29,31 @@ function CreateNote({ contents, handleChangeFn }: CreateNoteProps) {
       setClickedTextColor(e.currentTarget.id);
     } else {
       setclickedBgColor(e.currentTarget.id);
+      setIsIconClicked(false);
     }
+  };
+
+  const handleClickedIcon = () => {
+    setIsIconClicked(true);
   };
 
   return (
     <S.Wrapper>
       <WriteNote
+        isIconClicked={isIconClicked}
         clickedBgColor={clickedBgColor}
         clickedTextColor={clickedTextColor}
         contents={contents}
         handleChangeFn={handleChangeFn}
       />
       <SelectColor
+        isIconClicked={isIconClicked}
         clickedCategory={clickedCategory}
         clickedTextColor={clickedTextColor}
         clickedBgColor={clickedBgColor}
         handleCategoryFn={handleClickCategory}
         handleColorFn={handleClickedColorBtn}
+        handleIconFn={handleClickedIcon}
       />
     </S.Wrapper>
   );

--- a/src/LecueNote/components/CreateNote/index.tsx
+++ b/src/LecueNote/components/CreateNote/index.tsx
@@ -5,11 +5,12 @@ import {
   CATEGORY,
   TEXT_COLOR_CHART,
 } from '../../constants/colorChart';
+import { CreateNoteProps } from '../../type/lecueNoteType';
 import SelectColor from '../SelectColor';
 import WriteNote from '../WriteNote';
 import * as S from './CreateNote.style';
 
-function CreateNote() {
+function CreateNote({ contents, handleChangeFn }: CreateNoteProps) {
   const [clickedCategory, setclickedCategory] = useState(CATEGORY[0]);
   const [clickedTextColor, setClickedTextColor] = useState(TEXT_COLOR_CHART[0]);
   const [clickedBgColor, setclickedBgColor] = useState(BG_COLOR_CHART[0]);
@@ -35,6 +36,8 @@ function CreateNote() {
       <WriteNote
         clickedBgColor={clickedBgColor}
         clickedTextColor={clickedTextColor}
+        contents={contents}
+        handleChangeFn={handleChangeFn}
       />
       <SelectColor
         clickedCategory={clickedCategory}

--- a/src/LecueNote/components/Footer/index.tsx
+++ b/src/LecueNote/components/Footer/index.tsx
@@ -1,10 +1,11 @@
 import Button from '../../../components/common/Button';
+import { FooterProps } from '../../type/lecueNoteType';
 import * as S from './Footer.style';
 
-function Footer() {
+function Footer({ contents }: FooterProps) {
   return (
     <S.Wrapper>
-      <Button variant="complete" disabled={true}>
+      <Button variant="complete" disabled={contents.length === 0}>
         작성 완료
       </Button>
     </S.Wrapper>

--- a/src/LecueNote/components/SelectColor/SelectColor.style.ts
+++ b/src/LecueNote/components/SelectColor/SelectColor.style.ts
@@ -3,14 +3,12 @@ import styled from '@emotion/styled';
 
 export const Wrapper = styled.article`
   display: flex;
-  flex-direction: column;
-
   gap: 1.8rem;
+  flex-direction: column;
 `;
 
 export const CategoryWrapper = styled.div`
   display: flex;
-
   gap: 1.4rem;
 `;
 

--- a/src/LecueNote/components/SelectColor/index.tsx
+++ b/src/LecueNote/components/SelectColor/index.tsx
@@ -8,11 +8,13 @@ import ShowColorChart from '../ShowColorChart';
 import * as S from './SelectColor.style';
 
 function SelectColor({
+  isIconClicked,
   clickedCategory,
   clickedTextColor,
   clickedBgColor,
   handleCategoryFn,
   handleColorFn,
+  handleIconFn,
 }: SelectColorProps) {
   return (
     <S.Wrapper>
@@ -33,15 +35,19 @@ function SelectColor({
 
       {clickedCategory === '텍스트색' ? (
         <ShowColorChart
+        isIconClicked={isIconClicked}
           colorChart={TEXT_COLOR_CHART}
           state={clickedTextColor}
           handleFn={handleColorFn}
+          handleIconFn={handleIconFn}
         />
       ) : (
         <ShowColorChart
+        isIconClicked={isIconClicked}
           colorChart={BG_COLOR_CHART}
           state={clickedBgColor}
           handleFn={handleColorFn}
+          handleIconFn={handleIconFn}
         />
       )}
     </S.Wrapper>

--- a/src/LecueNote/components/ShowColorChart/ShowColorChart.style.ts
+++ b/src/LecueNote/components/ShowColorChart/ShowColorChart.style.ts
@@ -12,6 +12,20 @@ export const Wrapper = styled.div`
   overflow-x: scroll;
 `;
 
+export const IconWrapper = styled.button<{ $isIconClicked: boolean }>`
+  ${({ theme, $isIconClicked }) =>
+    $isIconClicked &&
+    css`
+      outline: 0.1rem solid ${theme.colors.WG};
+    `};
+  flex-shrink: 0;
+
+  width: 3.8rem;
+  height: 3.8rem;
+
+  border-radius: 3rem;
+`;
+
 export const ColorWrapper = styled.div`
   display: flex;
   justify-content: center;
@@ -22,7 +36,11 @@ export const ColorWrapper = styled.div`
   height: 3.8rem;
 `;
 
-export const Color = styled.button<{ $colorCode: string; variant: boolean }>`
+export const Color = styled.button<{
+  $isIconClicked: boolean;
+  $colorCode: string;
+  variant: boolean;
+}>`
   border-radius: 3rem;
   ${({ $colorCode, theme }) =>
     $colorCode === '#FFF' &&
@@ -31,19 +49,26 @@ export const Color = styled.button<{ $colorCode: string; variant: boolean }>`
     `};
   background-color: ${({ $colorCode }) => $colorCode};
 
-  ${({ variant, theme }) =>
-    variant
+  ${({ variant, theme, $isIconClicked }) =>
+    $isIconClicked
       ? css`
-          width: 3.8rem;
-          height: 3.8rem;
-
-          border: 0.4rem solid ${theme.colors.white};
-          outline: 0.1rem solid ${theme.colors.WG};
-        `
-      : css`
           width: 3rem;
           height: 3rem;
 
           border: none;
-        `};
+        `
+      : variant
+        ? css`
+            width: 3.8rem;
+            height: 3.8rem;
+
+            border: 0.4rem solid ${theme.colors.white};
+            outline: 0.1rem solid ${theme.colors.WG};
+          `
+        : css`
+            width: 3rem;
+            height: 3rem;
+
+            border: none;
+          `};
 `;

--- a/src/LecueNote/components/ShowColorChart/ShowColorChart.style.ts
+++ b/src/LecueNote/components/ShowColorChart/ShowColorChart.style.ts
@@ -3,14 +3,13 @@ import styled from '@emotion/styled';
 
 export const Wrapper = styled.div`
   display: flex;
+  gap: 1.4rem;
   justify-content: flex-start;
   align-items: center;
 
   padding: 0.5rem 0.1rem 0.7rem 0.3rem;
 
   overflow-x: scroll;
-
-  gap: 1.4rem;
 `;
 
 export const ColorWrapper = styled.div`

--- a/src/LecueNote/components/ShowColorChart/index.tsx
+++ b/src/LecueNote/components/ShowColorChart/index.tsx
@@ -1,15 +1,31 @@
+import { IcCameraSmall } from '../../../assets';
+import { BG_COLOR_CHART } from '../../constants/colorChart';
 import { ShowColorChartProps } from '../../type/lecueNoteType';
 import * as S from './ShowColorChart.style';
 
-function ShowColorChart({ colorChart, state, handleFn }: ShowColorChartProps) {
+function ShowColorChart({
+  isIconClicked,
+  colorChart,
+  state,
+  handleFn,
+  handleIconFn,
+}: ShowColorChartProps) {
   return (
     <S.Wrapper>
+      {colorChart === BG_COLOR_CHART && (
+        <S.IconWrapper onClick={handleIconFn} $isIconClicked={isIconClicked}>
+          <IcCameraSmall />
+        </S.IconWrapper>
+      )}
       {colorChart.map((colorCode) => (
         <S.ColorWrapper key={colorCode}>
           <S.Color
             type="button"
             id={colorCode}
             variant={state === colorCode}
+            $isIconClicked={
+              colorChart === BG_COLOR_CHART ? isIconClicked : false
+            }
             $colorCode={colorCode}
             onClick={handleFn}
           ></S.Color>

--- a/src/LecueNote/components/WriteNote/WriteNote.style.ts
+++ b/src/LecueNote/components/WriteNote/WriteNote.style.ts
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Wrapper = styled.div`
@@ -6,7 +7,10 @@ export const Wrapper = styled.div`
   flex-direction: column;
 `;
 
-export const LecueNote = styled.article<{ $bgColor: string }>`
+export const LecueNote = styled.article<{
+  $bgColor: string;
+  $isIconClicked: boolean;
+}>`
   display: flex;
   flex-direction: column;
 
@@ -14,7 +18,20 @@ export const LecueNote = styled.article<{ $bgColor: string }>`
   height: calc(100dvh - 33.2rem);
 
   border-radius: 0.6rem;
-  background-color: ${({ $bgColor }) => $bgColor};
+
+  ${({ $isIconClicked, $bgColor }) =>
+    $isIconClicked
+      ? css`
+          width: 100%;
+          height: calc(100dvh - 33.2rem);
+
+          background-size: contain;
+
+          background-image: url('https://velog.velcdn.com/images/aroo_ming/post/a9437eb2-9104-4c8b-912f-1a8b6eaf6f9d/image.jpeg');
+        `
+      : css`
+          background-color: ${$bgColor};
+        `};
 `;
 
 export const Nickname = styled.p`

--- a/src/LecueNote/components/WriteNote/WriteNote.style.ts
+++ b/src/LecueNote/components/WriteNote/WriteNote.style.ts
@@ -7,11 +7,50 @@ export const Wrapper = styled.div`
 `;
 
 export const LecueNote = styled.article<{ $bgColor: string }>`
+  display: flex;
+  flex-direction: column;
+
   width: 100%;
   height: calc(100dvh - 33.2rem);
 
   border-radius: 0.6rem;
   background-color: ${({ $bgColor }) => $bgColor};
+`;
+
+export const Nickname = styled.p`
+  margin: 2rem 0 1rem 2rem;
+
+  ${({ theme }) => theme.fonts.Head1_B_20}
+`;
+
+export const Contents = styled.textarea<{ $textColor: string }>`
+  width: calc(100% - 4rem);
+  height: 100%;
+  margin: 0 2rem 2rem;
+
+  border: none;
+  ${({ theme }) => theme.fonts.Body1_R_16};
+  background-color: transparent;
+  color: ${({ $textColor }) => $textColor};
+`;
+
+export const BottomContentsWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  width: calc(100% - 4rem);
+  height: 1.7rem;
+  margin: 0 2rem 2rem;
+`;
+
+export const Date = styled.p`
+  ${({ theme }) => theme.fonts.E_Body2_R_14};
+  color: ${({ theme }) => theme.colors.DG50};
+`;
+
+export const Counter = styled.p`
+  ${({ theme }) => theme.fonts.E_Body2_R_14};
+  color: ${({ theme }) => theme.colors.DG};
 `;
 
 export const Notice = styled.p`

--- a/src/LecueNote/components/WriteNote/WriteNote.style.ts
+++ b/src/LecueNote/components/WriteNote/WriteNote.style.ts
@@ -2,14 +2,13 @@ import styled from '@emotion/styled';
 
 export const Wrapper = styled.div`
   display: flex;
+  gap: 0.6rem;
   flex-direction: column;
-
-  gap: 0.4rem;
 `;
 
 export const LecueNote = styled.article<{ $bgColor: string }>`
   width: 100%;
-  height: calc(100dvh - 33rem);
+  height: calc(100dvh - 33.2rem);
 
   border-radius: 0.6rem;
   background-color: ${({ $bgColor }) => $bgColor};

--- a/src/LecueNote/components/WriteNote/index.tsx
+++ b/src/LecueNote/components/WriteNote/index.tsx
@@ -3,8 +3,14 @@ import { useEffect, useState } from 'react';
 import { WriteNoteProps } from '../../type/lecueNoteType';
 import * as S from './WriteNote.style';
 
-function WriteNote({ clickedBgColor, clickedTextColor }: WriteNoteProps) {
+function WriteNote({
+  clickedBgColor,
+  clickedTextColor,
+  contents,
+  handleChangeFn,
+}: WriteNoteProps) {
   const nickname = '와라라라랄라';
+
   const today = new Date();
   const [dateArr, setDateArr] = useState([0, 0, 0]);
 
@@ -16,12 +22,12 @@ function WriteNote({ clickedBgColor, clickedTextColor }: WriteNoteProps) {
     <S.Wrapper>
       <S.LecueNote $bgColor={clickedBgColor}>
         <S.Nickname>{nickname}</S.Nickname>
-        <S.Contents $textColor={clickedTextColor} />
+        <S.Contents $textColor={clickedTextColor} onChange={handleChangeFn} />
         <S.BottomContentsWrapper>
           <S.Date>
             {dateArr[0]}.{dateArr[1]}.{dateArr[2]}
           </S.Date>
-          <S.Counter>(1/1000)</S.Counter>
+          <S.Counter>({contents.length}/1000)</S.Counter>
         </S.BottomContentsWrapper>
       </S.LecueNote>
       <S.Notice>*욕설/비속어는 자동 필터링됩니다.</S.Notice>

--- a/src/LecueNote/components/WriteNote/index.tsx
+++ b/src/LecueNote/components/WriteNote/index.tsx
@@ -1,10 +1,19 @@
 import { WriteNoteProps } from '../../type/lecueNoteType';
 import * as S from './WriteNote.style';
 
-function WriteNote({ clickedBgColor }: WriteNoteProps) {
+function WriteNote({ clickedBgColor, clickedTextColor }: WriteNoteProps) {
+  const nickname = '와라라라랄라';
+
   return (
     <S.Wrapper>
-      <S.LecueNote $bgColor={clickedBgColor}></S.LecueNote>
+      <S.LecueNote $bgColor={clickedBgColor}>
+        <S.Nickname>{nickname}</S.Nickname>
+        <S.Contents $textColor={clickedTextColor} />
+        <S.BottomContentsWrapper>
+          <S.Date>2020.10.23</S.Date>
+          <S.Counter>(1/1000)</S.Counter>
+        </S.BottomContentsWrapper>
+      </S.LecueNote>
       <S.Notice>*욕설/비속어는 자동 필터링됩니다.</S.Notice>
     </S.Wrapper>
   );

--- a/src/LecueNote/components/WriteNote/index.tsx
+++ b/src/LecueNote/components/WriteNote/index.tsx
@@ -21,7 +21,7 @@ function WriteNote({
 
   return (
     <S.Wrapper>
-      <S.LecueNote $bgColor={isIconClicked ? 'white' : clickedBgColor}>
+      <S.LecueNote $bgColor={clickedBgColor} $isIconClicked={isIconClicked}>
         <S.Nickname>{nickname}</S.Nickname>
         <S.Contents $textColor={clickedTextColor} onChange={handleChangeFn} />
         <S.BottomContentsWrapper>

--- a/src/LecueNote/components/WriteNote/index.tsx
+++ b/src/LecueNote/components/WriteNote/index.tsx
@@ -1,8 +1,16 @@
+import { useEffect, useState } from 'react';
+
 import { WriteNoteProps } from '../../type/lecueNoteType';
 import * as S from './WriteNote.style';
 
 function WriteNote({ clickedBgColor, clickedTextColor }: WriteNoteProps) {
   const nickname = '와라라라랄라';
+  const today = new Date();
+  const [dateArr, setDateArr] = useState([0, 0, 0]);
+
+  useEffect(() => {
+    setDateArr([today.getFullYear(), today.getMonth() + 1, today.getDate()]);
+  }, [today.getDate()]);
 
   return (
     <S.Wrapper>
@@ -10,7 +18,9 @@ function WriteNote({ clickedBgColor, clickedTextColor }: WriteNoteProps) {
         <S.Nickname>{nickname}</S.Nickname>
         <S.Contents $textColor={clickedTextColor} />
         <S.BottomContentsWrapper>
-          <S.Date>2020.10.23</S.Date>
+          <S.Date>
+            {dateArr[0]}.{dateArr[1]}.{dateArr[2]}
+          </S.Date>
           <S.Counter>(1/1000)</S.Counter>
         </S.BottomContentsWrapper>
       </S.LecueNote>

--- a/src/LecueNote/components/WriteNote/index.tsx
+++ b/src/LecueNote/components/WriteNote/index.tsx
@@ -4,6 +4,7 @@ import { WriteNoteProps } from '../../type/lecueNoteType';
 import * as S from './WriteNote.style';
 
 function WriteNote({
+  isIconClicked,
   clickedBgColor,
   clickedTextColor,
   contents,
@@ -20,7 +21,7 @@ function WriteNote({
 
   return (
     <S.Wrapper>
-      <S.LecueNote $bgColor={clickedBgColor}>
+      <S.LecueNote $bgColor={isIconClicked ? 'white' : clickedBgColor}>
         <S.Nickname>{nickname}</S.Nickname>
         <S.Contents $textColor={clickedTextColor} onChange={handleChangeFn} />
         <S.BottomContentsWrapper>

--- a/src/LecueNote/page/LeceuNotePage/LecueNotePage.style.ts
+++ b/src/LecueNote/page/LeceuNotePage/LecueNotePage.style.ts
@@ -9,6 +9,5 @@ export const Wrapper = styled.div`
 
   width: 100vw;
   height: 100dvh;
-
   padding: 0 1.7rem;
 `;

--- a/src/LecueNote/page/LeceuNotePage/index.tsx
+++ b/src/LecueNote/page/LeceuNotePage/index.tsx
@@ -1,14 +1,26 @@
+import { useState } from 'react';
+
 import Header from '../../../components/common/Header';
 import CreateNote from '../../components/CreateNote';
 import Footer from '../../components/Footer';
 import * as S from './LecueNotePage.style';
 
 function LecueNotePage() {
+  const MAX_LENGTH = 1000;
+  const [contents, setContents] = useState('');
+
+  const handleChangeContents = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setContents(e.target.value);
+    if (e.target.value.length > MAX_LENGTH) {
+      setContents((e.target.value = e.target.value.substring(0, 1000)));
+    }
+  };
+
   return (
     <S.Wrapper>
-      <Header headerTitle='레큐노트 작성'/>
-      <CreateNote />
-      <Footer />
+      <Header headerTitle="레큐노트 작성" />
+      <CreateNote contents={contents} handleChangeFn={handleChangeContents} />
+      <Footer contents={contents} />
     </S.Wrapper>
   );
 }

--- a/src/LecueNote/page/LeceuNotePage/index.tsx
+++ b/src/LecueNote/page/LeceuNotePage/index.tsx
@@ -6,7 +6,7 @@ import * as S from './LecueNotePage.style';
 function LecueNotePage() {
   return (
     <S.Wrapper>
-      <Header headerTitle='레큐 노트'/>
+      <Header headerTitle='레큐노트 작성'/>
       <CreateNote />
       <Footer />
     </S.Wrapper>

--- a/src/LecueNote/page/LeceuNotePage/index.tsx
+++ b/src/LecueNote/page/LeceuNotePage/index.tsx
@@ -12,7 +12,7 @@ function LecueNotePage() {
   const handleChangeContents = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setContents(e.target.value);
     if (e.target.value.length > MAX_LENGTH) {
-      setContents((e.target.value = e.target.value.substring(0, 1000)));
+      setContents((e.target.value = e.target.value.substring(0, MAX_LENGTH)));
     }
   };
 

--- a/src/LecueNote/type/lecueNoteType.ts
+++ b/src/LecueNote/type/lecueNoteType.ts
@@ -16,4 +16,5 @@ export interface ShowColorChartProps {
 
 export interface WriteNoteProps {
   clickedBgColor: string;
+  clickedTextColor: string;
 }

--- a/src/LecueNote/type/lecueNoteType.ts
+++ b/src/LecueNote/type/lecueNoteType.ts
@@ -4,6 +4,7 @@ export interface CreateNoteProps {
 }
 
 export interface SelectColorProps {
+  isIconClicked: boolean;
   clickedCategory: string;
   clickedTextColor: string;
   clickedBgColor: string;
@@ -11,15 +12,19 @@ export interface SelectColorProps {
     e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => void;
   handleColorFn: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  handleIconFn: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
 export interface ShowColorChartProps {
+  isIconClicked: boolean;
   colorChart: string[];
   state: string;
   handleFn: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  handleIconFn: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
 export interface WriteNoteProps extends CreateNoteProps {
+  isIconClicked: boolean;
   clickedBgColor: string;
   clickedTextColor: string;
 }

--- a/src/LecueNote/type/lecueNoteType.ts
+++ b/src/LecueNote/type/lecueNoteType.ts
@@ -1,3 +1,8 @@
+export interface CreateNoteProps {
+  contents: string;
+  handleChangeFn: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
 export interface SelectColorProps {
   clickedCategory: string;
   clickedTextColor: string;
@@ -14,7 +19,11 @@ export interface ShowColorChartProps {
   handleFn: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
-export interface WriteNoteProps {
+export interface WriteNoteProps extends CreateNoteProps {
   clickedBgColor: string;
   clickedTextColor: string;
+}
+
+export interface FooterProps {
+  contents: string;
 }

--- a/src/assets/icon/ic_camera_small.svg
+++ b/src/assets/icon/ic_camera_small.svg
@@ -1,0 +1,6 @@
+<svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="19" cy="19" r="19" fill="#DDDDDD"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.7412 12C16.4113 12 16.1206 12.217 16.0269 12.5334L15.5925 14H12.4899C11.667 14 11 14.667 11 15.4899V24.5101C11 25.333 11.667 26 12.4899 26H25.5101C26.333 26 27 25.333 27 24.5101V15.4899C27 14.667 26.333 14 25.5101 14H24.4075L23.9731 12.5334C23.8794 12.217 23.5887 12 23.2588 12H16.7412Z" fill="#494949"/>
+<circle cx="19" cy="20" r="3.50889" fill="#9E9E9E" stroke="#DDDDDD" stroke-width="0.982211"/>
+<circle cx="23.5" cy="16.5" r="0.5" fill="#D9D9D9"/>
+</svg>

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -10,6 +10,7 @@ import BtnKakaologin from './button/btn_kakaologin.svg?react';
 import IcArrowLeftBlack from './icon/ic_arrow_left_black.svg?react';
 import IcArrowLeftWhite from './icon/ic_arrow_left_white.svg?react';
 import IcCamera from './icon/ic_camera.svg?react';
+import IcCameraSmall from './icon/ic_camera_small.svg?react';
 import IcCrown from './icon/ic_crown.svg?react';
 import IcDate from './icon/ic_date.svg?react';
 import IcHome from './icon/ic_home.svg?react';
@@ -43,6 +44,7 @@ export {
   IcArrowLeftBlack,
   IcArrowLeftWhite,
   IcCamera,
+  IcCameraSmall,
   IcCrown,
   IcDate,
   IcHome,
@@ -60,8 +62,8 @@ export {
   ImgKakaoStarWhite,
   ImgLe,
   ImgLogoLecue,
+  ImgSplashLogo,
   ImgStarOrangeLine,
   ImgStarPosit,
   ImgSticker,
-  ImgSplashLogo,
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #35 

## ✅ 작업 내용

- [x] 닉네임, 생성일자, 글자수 제한 기능 구현
- [x] 하단 버튼 비활성화 조건 추가
- [x] 화면 비율이 길어짐에 따라 포스트잇 길이 늘어나게 구현 (디자인과 상의된 부분)
- [x] 레큐노트 내부 스크롤 구현 
- [x] presigned url을 넣기 전에 하나의 목업 이미지를 넣어줌 

## 📸 스크린샷 / GIF / Link

https://github.com/Team-Lecue/Lecue-Client/assets/80264647/aea0b54a-4386-49c6-a864-e8f50b55dd3d


https://github.com/Team-Lecue/Lecue-Client/assets/80264647/38e25bb8-435c-43d5-948f-f0fc65d6a0ef




## 📌 이슈 사항
- 막상 구현해보니 생성일자가 눈에 너무 안띄어서 이 부분 말씀드려볼 예정입니다.
- 글자 수가 1000자 이상일 경우, 지금은 별다른 경고창 없이 1000자만큼 글자가 잘립니다!
  - 개인적으로는 이 부분 UX가 좋지 않은 것 같아서, 이 부분 역시 말씀드려보고 가능하다면 alert나 모달 등을 추가할 예정입니다.   