### PR TITLE
[ StickerAttach ] 스크롤 위치 복원 + 버그 픽스

### DIFF
--- a/src/Detail/components/LecueNoteListContainer/index.tsx
+++ b/src/Detail/components/LecueNoteListContainer/index.tsx
@@ -62,11 +62,9 @@ function LecueNoteListContainer({
         postedStickerId: stickerId,
         stickerImage: stickerImage,
       }));
-      sessionStorage.removeItem('scrollPosition');
     } else {
       // editable 상태 변경
       setIsEditable(false);
-      navigate('/lecue-book');
     }
   }, [state]);
 
@@ -105,8 +103,6 @@ function LecueNoteListContainer({
     });
 
     setIsEditable(false);
-
-    navigate('/lecue-book');
   };
 
   return (

--- a/src/Detail/components/LecueNoteListContainer/index.tsx
+++ b/src/Detail/components/LecueNoteListContainer/index.tsx
@@ -73,8 +73,8 @@ function LecueNoteListContainer({
     const { positionX, positionY } = stickerState;
     setStickerState((prev) => ({
       ...prev,
-      positionX: Math.ceil(positionX + ui.deltaX),
-      positionY: Math.ceil(positionY + ui.deltaY),
+      positionX: positionX + ui.deltaX,
+      positionY: positionY + ui.deltaY,
     }));
   };
 

--- a/src/Detail/components/LecueNoteListContainer/index.tsx
+++ b/src/Detail/components/LecueNoteListContainer/index.tsx
@@ -75,8 +75,8 @@ function LecueNoteListContainer({
     const { positionX, positionY } = stickerState;
     setStickerState((prev) => ({
       ...prev,
-      positionX: positionX + ui.deltaX,
-      positionY: positionY + ui.deltaY,
+      positionX: Math.ceil(positionX + ui.deltaX),
+      positionY: Math.ceil(positionY + ui.deltaY),
     }));
   };
 

--- a/src/Detail/components/LecueNoteListContainer/index.tsx
+++ b/src/Detail/components/LecueNoteListContainer/index.tsx
@@ -10,6 +10,7 @@ import {
   IcCaution,
 } from '../../../assets';
 import Button from '../../../components/common/Button';
+import usePostStickerState from '../../../StickerAttach/hooks/usePostStickerState';
 import { NoteType, postedStickerType } from '../../type/lecueBookType';
 import LecueNoteListHeader from '../LecueNoteLIstHeader';
 import LinearView from '../LinearView';
@@ -52,7 +53,7 @@ function LecueNoteListContainer({
   const postMutation = usePostStickerState();
 
   useEffect(() => {
-    // editable 상태 변경
+    // state : 라우터 타고 온 스티커 값, 즉 스티커 값을 갖고 있는 상태라면
     if (state) {
       window.scrollTo(0, savedScrollPosition);
       const { stickerId, stickerImage } = state.sticker;

--- a/src/Detail/components/LecueNoteListContainer/index.tsx
+++ b/src/Detail/components/LecueNoteListContainer/index.tsx
@@ -89,7 +89,7 @@ function LecueNoteListContainer({
   };
 
   const handleClickWriteButton = () => {
-    alert('WriteBtn');
+    navigate('/create-note');
   };
 
   const handleClickDone = () => {

--- a/src/Detail/components/LecueNoteListContainer/index.tsx
+++ b/src/Detail/components/LecueNoteListContainer/index.tsx
@@ -22,6 +22,8 @@ interface LecueNoteListContainerProps {
   backgroundColor: string;
   noteList: NoteType[];
   postedStickerList: postedStickerType[];
+  isEditable: boolean;
+  setEditableStateFalse: () => void;
 }
 
 function LecueNoteListContainer({
@@ -29,6 +31,8 @@ function LecueNoteListContainer({
   backgroundColor,
   noteList,
   postedStickerList,
+  isEditable,
+  setEditableStateFalse,
 }: LecueNoteListContainerProps) {
   //hooks
   const location = useLocation();
@@ -40,7 +44,6 @@ function LecueNoteListContainer({
     storedValue !== null ? parseInt(storedValue, 10) : 0;
   //state
   const [isZigZagView, setIsZigZagView] = useState<boolean>(true);
-  const [isEditable, setIsEditable] = useState(true);
   const [stickerState, setStickerState] = useState<postedStickerType>({
     postedStickerId: 0,
     stickerImage: '',
@@ -64,9 +67,9 @@ function LecueNoteListContainer({
       }));
     } else {
       // editable 상태 변경
-      setIsEditable(false);
+      setEditableStateFalse();
     }
-  }, [state]);
+  }, [state, isEditable]);
 
   // 스티커 위치 값 저장
   const handleDrag = (_e: DraggableEvent, ui: DraggableData) => {
@@ -102,7 +105,7 @@ function LecueNoteListContainer({
       positionY: positionY,
     });
 
-    setIsEditable(false);
+    setEditableStateFalse();
   };
 
   return (

--- a/src/Detail/components/LecueNoteListContainer/index.tsx
+++ b/src/Detail/components/LecueNoteListContainer/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { DraggableData, DraggableEvent } from 'react-draggable';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -32,6 +32,7 @@ function LecueNoteListContainer({
   //hooks
   const location = useLocation();
   const navigate = useNavigate();
+  const scrollRef = useRef(document.createElement('div'));
   //storage
   const storedValue = sessionStorage.getItem('scrollPosition');
   const savedScrollPosition =
@@ -60,6 +61,7 @@ function LecueNoteListContainer({
         postedStickerId: stickerId,
         stickerImage: stickerImage,
       }));
+      sessionStorage.removeItem('scrollPosition');
     } else {
       // editable 상태 변경
       setIsEditable(false);
@@ -77,10 +79,10 @@ function LecueNoteListContainer({
     }));
   };
 
+  // 스티커 버튼 클릭시
   const handleClickStickerButton = () => {
+    // 현재 스크롤 위치 저장
     sessionStorage.setItem('scrollPosition', window.scrollY.toString());
-
-    setIsEditable(true);
 
     navigate('/sticker-pack');
   };
@@ -120,11 +122,13 @@ function LecueNoteListContainer({
       <S.LecueNoteListViewWrapper>
         {isZigZagView ? (
           <ZigZagView
+            savedScrollPosition={savedScrollPosition}
             noteList={noteList}
             isEditable={isEditable}
             handleDrag={handleDrag}
             stickerState={stickerState}
             postedStickerList={postedStickerList}
+            ref={scrollRef}
           />
         ) : (
           <LinearView noteList={noteList} />

--- a/src/Detail/components/ZigZagView/ZigZagView.style.ts
+++ b/src/Detail/components/ZigZagView/ZigZagView.style.ts
@@ -26,6 +26,8 @@ export const Sticker = styled.div<{
   stickerImage: string;
   isEditable?: boolean;
 }>`
+  position: absolute;
+
   width: 10rem;
   height: 10rem;
 

--- a/src/Detail/components/ZigZagView/ZigZagView.style.ts
+++ b/src/Detail/components/ZigZagView/ZigZagView.style.ts
@@ -17,8 +17,9 @@ export const LecueNoteContainer = styled.div`
 export const StickerContainer = styled.div`
   position: absolute;
 
-  width: 100%;
+  width: 34.2rem;
   height: 100%;
+  padding: 0.4rem 0 2rem;
 `;
 
 export const Sticker = styled.div<{
@@ -30,7 +31,7 @@ export const Sticker = styled.div<{
 
   ${({ isEditable, theme }) =>
     isEditable && `border: solid 0.1rem ${theme.colors.key}`};
-
+  border-radius: 0.4rem;
   background-position: center;
   background-image: ${({ stickerImage }) => `url(${stickerImage})`};
   background-repeat: no-repeat;

--- a/src/Detail/components/ZigZagView/index.tsx
+++ b/src/Detail/components/ZigZagView/index.tsx
@@ -40,7 +40,7 @@ const ZigZagView = forwardRef(function ZigZagView(
             onStart={() => false}
             nodeRef={nodeRef}
             key={data.postedStickerId}
-            positionOffset={{ x: data.positionX, y: data.positionY }}
+            defaultPosition={{ x: data.positionX, y: data.positionY }}
           >
             <S.Sticker ref={nodeRef} stickerImage={data.stickerImage} />
           </Draggable>

--- a/src/Detail/components/ZigZagView/index.tsx
+++ b/src/Detail/components/ZigZagView/index.tsx
@@ -55,7 +55,11 @@ const ZigZagView = forwardRef(function ZigZagView(
             bounds="parent"
             nodeRef={nodeRef}
           >
-            <S.Sticker ref={nodeRef} stickerImage={stickerState.stickerImage} />
+            <S.Sticker
+              ref={nodeRef}
+              stickerImage={stickerState.stickerImage}
+              isEditable
+            />
           </Draggable>
         )}
         </S.StickerContainer>

--- a/src/Detail/components/ZigZagView/index.tsx
+++ b/src/Detail/components/ZigZagView/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { forwardRef, useRef } from 'react';
 import Draggable, { DraggableData, DraggableEvent } from 'react-draggable';
 
 import { NoteType, postedStickerType } from '../../type/lecueBookType';
@@ -11,15 +11,20 @@ interface ZigZagViewProps {
   stickerState: postedStickerType;
   isEditable: boolean;
   postedStickerList: postedStickerType[];
+  savedScrollPosition: number;
 }
 
-function ZigZagView({
+const ZigZagView = forwardRef(function ZigZagView(
+  {
   noteList,
   handleDrag,
   stickerState,
   isEditable,
   postedStickerList,
-}: ZigZagViewProps) {
+    savedScrollPosition,
+  }: ZigZagViewProps,
+  ref: React.Ref<HTMLDivElement>,
+) {
   const nodeRef = useRef(null);
 
   return (
@@ -29,24 +34,23 @@ function ZigZagView({
           <SmallLecueNote {...note} noteList={noteList} />
         </S.LecueNoteContainer>
       ))}
-      <S.StickerContainer>
+      <S.StickerContainer ref={ref}>
         {postedStickerList.map((data) => (
           <Draggable
+            onStart={() => false}
             nodeRef={nodeRef}
             key={data.postedStickerId}
             positionOffset={{ x: data.positionX, y: data.positionY }}
-            onStart={() => false}
           >
             <S.Sticker ref={nodeRef} stickerImage={data.stickerImage} />
           </Draggable>
         ))}
       </S.StickerContainer>
       {isEditable && (
-        <S.StickerContainer>
           <Draggable
-            defaultPosition={{
-              x: stickerState.positionX,
-              y: stickerState.positionY,
+            positionOffset={{
+              x: 0,
+              y: savedScrollPosition,
             }}
             onDrag={handleDrag}
             bounds="parent"

--- a/src/Detail/components/ZigZagView/index.tsx
+++ b/src/Detail/components/ZigZagView/index.tsx
@@ -16,11 +16,11 @@ interface ZigZagViewProps {
 
 const ZigZagView = forwardRef(function ZigZagView(
   {
-  noteList,
-  handleDrag,
-  stickerState,
-  isEditable,
-  postedStickerList,
+    noteList,
+    handleDrag,
+    stickerState,
+    isEditable,
+    postedStickerList,
     savedScrollPosition,
   }: ZigZagViewProps,
   ref: React.Ref<HTMLDivElement>,
@@ -45,7 +45,7 @@ const ZigZagView = forwardRef(function ZigZagView(
             <S.Sticker ref={nodeRef} stickerImage={data.stickerImage} />
           </Draggable>
         ))}
-      {isEditable && (
+        {isEditable && (
           <Draggable
             positionOffset={{
               x: 0,
@@ -62,7 +62,7 @@ const ZigZagView = forwardRef(function ZigZagView(
             />
           </Draggable>
         )}
-        </S.StickerContainer>
+      </S.StickerContainer>
     </S.ZigZagViewWrapper>
   );
 });

--- a/src/Detail/components/ZigZagView/index.tsx
+++ b/src/Detail/components/ZigZagView/index.tsx
@@ -35,19 +35,9 @@ const ZigZagView = forwardRef(function ZigZagView(
         </S.LecueNoteContainer>
       ))}
       <S.StickerContainer ref={ref}>
-        {postedStickerList.map((data) => (
-          <Draggable
-            onStart={() => false}
-            nodeRef={nodeRef}
-            key={data.postedStickerId}
-            defaultPosition={{ x: data.positionX, y: data.positionY }}
-          >
-            <S.Sticker ref={nodeRef} stickerImage={data.stickerImage} />
-          </Draggable>
-        ))}
         {isEditable && (
           <Draggable
-            positionOffset={{
+            defaultPosition={{
               x: 0,
               y: savedScrollPosition,
             }}
@@ -62,6 +52,16 @@ const ZigZagView = forwardRef(function ZigZagView(
             />
           </Draggable>
         )}
+        {postedStickerList.map((data) => (
+          <Draggable
+            onStart={() => false}
+            nodeRef={nodeRef}
+            key={data.postedStickerId}
+            defaultPosition={{ x: data.positionX, y: data.positionY }}
+          >
+            <S.Sticker ref={nodeRef} stickerImage={data.stickerImage} />
+          </Draggable>
+        ))}
       </S.StickerContainer>
     </S.ZigZagViewWrapper>
   );

--- a/src/Detail/components/ZigZagView/index.tsx
+++ b/src/Detail/components/ZigZagView/index.tsx
@@ -45,7 +45,6 @@ const ZigZagView = forwardRef(function ZigZagView(
             <S.Sticker ref={nodeRef} stickerImage={data.stickerImage} />
           </Draggable>
         ))}
-      </S.StickerContainer>
       {isEditable && (
           <Draggable
             positionOffset={{
@@ -58,10 +57,9 @@ const ZigZagView = forwardRef(function ZigZagView(
           >
             <S.Sticker ref={nodeRef} stickerImage={stickerState.stickerImage} />
           </Draggable>
+        )}
         </S.StickerContainer>
-      )}
     </S.ZigZagViewWrapper>
   );
-}
-
+});
 export default ZigZagView;

--- a/src/Detail/page/DetailPage/index.tsx
+++ b/src/Detail/page/DetailPage/index.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import Header from '../../../components/common/Header';
 import BookInfoBox from '../../components/BookInfoBox';
 import LecueNoteListContainer from '../../components/LecueNoteListContainer';
@@ -7,15 +9,22 @@ import * as S from './DetailPage.style';
 
 function DetailPage() {
   const { bookDetail } = useGetBookDetail();
+  const [isEditable, setIsEditable] = useState(true);
+
+  const setEditableStateFalse = () => {
+    setIsEditable(false);
+  };
 
   return bookDetail ? (
     <S.DetailPageWrapper>
-      <Header headerTitle="레큐북" isDetailPage />
+      <Header headerTitle="레큐북" isDetailPage={!isEditable} />
       <S.DetailPageBodyWrapper>
         <SlideBanner name={bookDetail.favoriteName} />
         <S.LecueBookContainer>
           <BookInfoBox {...bookDetail} />
           <LecueNoteListContainer
+            isEditable={isEditable}
+            setEditableStateFalse={setEditableStateFalse}
             noteNum={bookDetail.noteNum}
             backgroundColor={bookDetail.bookBackgroundColor}
             noteList={bookDetail.noteList}
@@ -26,7 +35,7 @@ function DetailPage() {
     </S.DetailPageWrapper>
   ) : (
     //TODO 에러페이지로 route
-    <div>uuid가 틀려서 아무것도 안보임</div>
+    <div>에러에러에러에러</div>
   );
 }
 

--- a/src/StickerAttach/hooks/usePostStickerState.ts
+++ b/src/StickerAttach/hooks/usePostStickerState.ts
@@ -23,7 +23,6 @@ const usePostStickerState = () => {
     },
     onSuccess: () => {
       navigate('/lecue-book');
-      sessionStorage.removeItem('scrollPosition');
     },
 
     onError: (err: AxiosError) => console.log(err),

--- a/src/StickerAttach/hooks/usePostStickerState.ts
+++ b/src/StickerAttach/hooks/usePostStickerState.ts
@@ -1,10 +1,12 @@
 import { AxiosError } from 'axios';
 import { useMutation } from 'react-query';
+import { useNavigate } from 'react-router-dom';
 
 import { postStickerState } from '../api/postStickerState';
 import { postedStickerParams } from '../type/postStickerType';
 
 const usePostStickerState = () => {
+  const navigate = useNavigate();
   const mutation = useMutation({
     mutationFn: ({
       postedStickerId,
@@ -19,6 +21,11 @@ const usePostStickerState = () => {
         positionY,
       });
     },
+    onSuccess: () => {
+      navigate('/lecue-book');
+      sessionStorage.removeItem('scrollPosition');
+    },
+
     onError: (err: AxiosError) => console.log(err),
   });
   return mutation;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #121 

## ✅ 작업 내용

- [x] 북 -> 스티커 부착 페이지 이동시 북에서의 스크롤 위치를 스티커 페이지에서 복원 시켰습니다.
- [x] 부착 위치가 애매하게 안 맞는 버그를 수정했습니다.
- [x] 스티커 부착 후 리렌더링 되지 않는 버그를 수정했습니다.
- [x] 글쓰기 버튼 클릭시 글쓰기 페이지로 이동하는 라우트를 추가했습니다.

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
