### PR TITLE
[ DetailPage ] Modal X 버튼 클릭 시 삭제 Event 바인딩 오류 FIX

### DIFF
--- a/src/Detail/components/LecueNoteModal/index.tsx
+++ b/src/Detail/components/LecueNoteModal/index.tsx
@@ -9,16 +9,17 @@ const modalContainer = document.getElementById(
 
 interface LecueNoteModalProps {
   selectedNote: NoteType | undefined;
+  closeModal: () => void;
 }
 
-function LecueNoteModal({ selectedNote }: LecueNoteModalProps) {
+function LecueNoteModal({ selectedNote, closeModal }: LecueNoteModalProps) {
   return createPortal(
     <S.BlurryContainer>
       <S.LecueNoteModalWrapper
         noteBackground={selectedNote?.noteBackground}
         noteTextColor={selectedNote?.noteTextColor || 0}
       >
-        <S.CloseButton type="button">
+        <S.CloseButton type="button" onClick={() => closeModal()}>
           <IcX />
         </S.CloseButton>
         <S.LecueNoteModalNickname>

--- a/src/Detail/components/LecueNoteModal/index.tsx
+++ b/src/Detail/components/LecueNoteModal/index.tsx
@@ -13,13 +13,19 @@ interface LecueNoteModalProps {
 }
 
 function LecueNoteModal({ selectedNote, closeModal }: LecueNoteModalProps) {
+  const handleCloseButtonClick = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.stopPropagation();
+    closeModal();
+  };
   return createPortal(
     <S.BlurryContainer>
       <S.LecueNoteModalWrapper
         noteBackground={selectedNote?.noteBackground}
         noteTextColor={selectedNote?.noteTextColor || 0}
       >
-        <S.CloseButton type="button" onClick={() => closeModal()}>
+        <S.CloseButton type="button" onClick={handleCloseButtonClick}>
           <IcX />
         </S.CloseButton>
         <S.LecueNoteModalNickname>

--- a/src/Detail/components/SmallLecueNote/index.tsx
+++ b/src/Detail/components/SmallLecueNote/index.tsx
@@ -31,7 +31,7 @@ function SmallLecueNote({
 
   const handleClickSmallLecueNote = () => {
     const clickedNote = getClickedNote();
-    if (clickedNote && modalShow === false) {
+    if (clickedNote) {
       setModalShow(true);
     }
   };

--- a/src/Detail/components/SmallLecueNote/index.tsx
+++ b/src/Detail/components/SmallLecueNote/index.tsx
@@ -31,8 +31,8 @@ function SmallLecueNote({
 
   const handleClickSmallLecueNote = () => {
     const clickedNote = getClickedNote();
-    if (clickedNote) {
-      setModalShow((prevModalShow) => !prevModalShow);
+    if (clickedNote && modalShow === false) {
+      setModalShow(true);
     }
   };
 
@@ -48,7 +48,12 @@ function SmallLecueNote({
         <S.SmallLecueNoteContent>{content}</S.SmallLecueNoteContent>
       </S.SmallLecueNoteContentWrapper>
       <S.SmallLecueNoteDate>{noteDate}</S.SmallLecueNoteDate>
-      {modalShow && <LecueNoteModal selectedNote={getClickedNote()} />}
+      {modalShow && (
+        <LecueNoteModal
+          selectedNote={getClickedNote()}
+          closeModal={() => setModalShow(false)}
+        />
+      )}
     </S.SmallLecueNoteWrapper>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,18 @@
-import { sentryVitePlugin } from "@sentry/vite-plugin";
+import { sentryVitePlugin } from '@sentry/vite-plugin';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), svgr(), sentryVitePlugin({
-    org: "lecue",
-    project: "javascript-react"
-  })],
+  plugins: [
+    react(),
+    svgr(),
+    sentryVitePlugin({
+      org: 'lecue',
+      project: 'javascript-react',
+    }),
+  ],
 
   server: {
     hmr: {
@@ -17,6 +21,6 @@ export default defineConfig({
   },
 
   build: {
-    sourcemap: true
-  }
+    sourcemap: true,
+  },
 });


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #135 

## ✅ 작업 내용

- [x] 모달 X 버튼 클릭 시 삭제 Event 바인딩

## 📸 스크린샷 / GIF / Link

https://github.com/Team-Lecue/Lecue-Client/assets/60962533/1f7df349-894b-474f-9a87-a9c040c91209



## 📌 이슈 사항
모달이 열리고 X버튼을 눌러도 modalShow가 true로 유지되면서 모달이 닫히지 않는 문제가 있었습니다.
문제를 해결하기 위해 호출 순서를 추적했는데, X 버튼을 눌렀을 때 자식 컴포넌트인 LecueNoteModal의 클릭 이벤트 핸들러가 먼저 동작한 직후 부모 컴포넌트인 SmallLecueNote의 클릭 이벤트 핸들러도 같이 동작하여  modalShow가 false -> true로 바뀌며 결국 true로 유지되는 문제였습니다.

=> 결국 하위 컴포넌트의 클릭 이벤트가 상위 컴포넌트로 전파되는 상황이기에 이벤트 버블링 문제라고 생각했고, X 버튼 클릭 이벤트 핸들러에  event.stopPropagation();을 추가해주어 이벤트 버블링을 차단시켰습니다. 그 결과 정상적으로 X 버튼을 누를 때만 모달이 닫히게 되었습니다 🙂
