### PR TITLE
[ Login ] React-Query 적용

### DIFF
--- a/src/Login/api/getLoginToken.ts
+++ b/src/Login/api/getLoginToken.ts
@@ -11,21 +11,16 @@ export const getLoginToken = async () => {
   const GRANT_TYPE = 'authorization_code';
 
   if (AUTHORIZE_CODE) {
-    try {
-      const response = await axios.post(
-        `${KAKAO_BASE_URL}/token?grant_type=${GRANT_TYPE}&client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&code=${AUTHORIZE_CODE}`,
-        {},
-        {
-          headers: {
-            'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
-          },
+    const response = await axios.post(
+      `${KAKAO_BASE_URL}/token?grant_type=${GRANT_TYPE}&client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&code=${AUTHORIZE_CODE}`,
+      {},
+      {
+        headers: {
+          'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
         },
-      );
+      },
+    );
 
-      return response.data.access_token;
-    } catch (error) {
-      console.error('로그인 토큰을 가져오는 중 에러 발생:', error);
-      throw error;
-    }
+    return response.data;
   }
 };

--- a/src/Login/api/getLoginToken.ts
+++ b/src/Login/api/getLoginToken.ts
@@ -9,17 +9,14 @@ import {
 export const getLoginToken = async () => {
   const AUTHORIZE_CODE = new URL(window.location.href).searchParams.get('code');
   const GRANT_TYPE = 'authorization_code';
+  const POST_URL = `grant_type=${GRANT_TYPE}&client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&code=${AUTHORIZE_CODE}`;
 
   if (AUTHORIZE_CODE) {
-    const response = await axios.post(
-      `${KAKAO_BASE_URL}/token?grant_type=${GRANT_TYPE}&client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&code=${AUTHORIZE_CODE}`,
-      {},
-      {
-        headers: {
-          'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
-        },
+    const response = await axios.post(`${KAKAO_BASE_URL}/token?${POST_URL}`, {
+      headers: {
+        'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
       },
-    );
+    });
 
     return response.data;
   }

--- a/src/Login/api/postLoginToken.ts
+++ b/src/Login/api/postLoginToken.ts
@@ -14,8 +14,5 @@ export const postLoginToken = async (token: string) => {
     },
   );
 
-  return {
-    nickname: response.data.data.nickname,
-    tokenDto: response.data.data.tokenDto,
-  };
+  return response.data.data;
 };

--- a/src/Login/components/LoginCallback/LoginCallback.tsx
+++ b/src/Login/components/LoginCallback/LoginCallback.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import LoadingPage from '../../../components/common/LoadingPage';
 import useGetLoginToken from '../../hooks/useGetLoginToken';
@@ -14,7 +14,9 @@ function LoginCallback() {
   const getMutation = useGetLoginToken({ handleLoginToken });
   const postMutation = usePostLoginToken();
 
-  loginToken === '' ? getMutation.mutate() : postMutation.mutate(loginToken);
+  useEffect(() => {
+    loginToken === '' ? getMutation.mutate() : postMutation.mutate(loginToken);
+  }, [loginToken]);
 
   return <LoadingPage />;
 }

--- a/src/Login/components/LoginCallback/LoginCallback.tsx
+++ b/src/Login/components/LoginCallback/LoginCallback.tsx
@@ -1,38 +1,15 @@
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 
-import { getLoginToken } from '../../api/getLoginToken';
-import { postLoginToken } from '../../api/postLoginToken';
+import useGetLoginToken from '../../hooks/useGetLoginToken';
+import usePostLoginToken from '../../hooks/usePostLoginToken';
 
 function LoginCallback() {
-  const navigate = useNavigate();
+  const [loginToken, setLoginToken] = useState('');
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const tokenRes = await getLoginToken();
+  const getMutation = useGetLoginToken({ loginToken, setLoginToken });
+  const postMutation = usePostLoginToken();
 
-        const { nickname, tokenDto } = await postLoginToken(tokenRes);
-
-        if (nickname === null || nickname === '') {
-          navigate('/register', { state: { token: tokenDto.accessToken } });
-        } else {
-          window.localStorage.setItem('token', tokenDto.accessToken);
-          window.localStorage.setItem('nickname', nickname);
-
-          if (sessionStorage.getItem('url') === '') {
-            navigate('/', { state: { step: 1 } });
-          } else {
-            navigate(-4);
-          }
-        }
-      } catch (error) {
-        console.error('로딩-fetchData() 에러 발생:', error);
-      }
-    };
-
-    fetchData();
-  }, []);
+  loginToken === '' ? getMutation.mutate() : postMutation.mutate(loginToken);
 
   return <></>;
 }

--- a/src/Login/components/LoginCallback/LoginCallback.tsx
+++ b/src/Login/components/LoginCallback/LoginCallback.tsx
@@ -6,7 +6,11 @@ import usePostLoginToken from '../../hooks/usePostLoginToken';
 function LoginCallback() {
   const [loginToken, setLoginToken] = useState('');
 
-  const getMutation = useGetLoginToken({ loginToken, setLoginToken });
+  const handleLoginToken = (token: string) => {
+    setLoginToken(token);
+  };
+
+  const getMutation = useGetLoginToken({ handleLoginToken });
   const postMutation = usePostLoginToken();
 
   loginToken === '' ? getMutation.mutate() : postMutation.mutate(loginToken);

--- a/src/Login/hooks/useGetLoginToken.ts
+++ b/src/Login/hooks/useGetLoginToken.ts
@@ -1,4 +1,3 @@
-import { AxiosError } from 'axios';
 import { useMutation } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
@@ -17,8 +16,7 @@ const useGetLoginToken = (props: useGetLoginTokenProps) => {
     mutationFn: async () => {
       return await getLoginToken();
     },
-    onError: (error: AxiosError) => {
-      console.error('로그인 토큰을 가져오는 중 에러 발생 : ', error);
+    onError: () => {
       navigate('/error');
     },
     onSuccess: (data) => {

--- a/src/Login/hooks/useGetLoginToken.ts
+++ b/src/Login/hooks/useGetLoginToken.ts
@@ -5,12 +5,11 @@ import { useNavigate } from 'react-router-dom';
 import { getLoginToken } from '../api/getLoginToken';
 
 interface useGetLoginTokenProps {
-  loginToken: string;
-  setLoginToken: React.Dispatch<React.SetStateAction<string>>;
+  handleLoginToken: (token: string) => void;
 }
 
 const useGetLoginToken = (props: useGetLoginTokenProps) => {
-  const { setLoginToken } = props;
+  const { handleLoginToken } = props;
 
   const navigate = useNavigate();
 
@@ -23,7 +22,7 @@ const useGetLoginToken = (props: useGetLoginTokenProps) => {
       navigate('/error');
     },
     onSuccess: (data) => {
-      setLoginToken(data.access_token);
+      handleLoginToken(data.access_token);
     },
   });
   return mutation;

--- a/src/Login/hooks/useGetLoginToken.ts
+++ b/src/Login/hooks/useGetLoginToken.ts
@@ -1,0 +1,25 @@
+import { AxiosError } from 'axios';
+import { useMutation } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { getLoginToken } from '../api/getLoginToken';
+
+const useGetLoginToken = () => {
+  const navigate = useNavigate();
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      return await getLoginToken();
+    },
+    onError: (error: AxiosError) => {
+      console.error('로그인 토큰을 가져오는 중 에러 발생 : ', error);
+      navigate('/error');
+    },
+    onSuccess: (data) => {
+      return data.access_token;
+    },
+  });
+  return mutation;
+};
+
+export default useGetLoginToken;

--- a/src/Login/hooks/useGetLoginToken.ts
+++ b/src/Login/hooks/useGetLoginToken.ts
@@ -4,7 +4,14 @@ import { useNavigate } from 'react-router-dom';
 
 import { getLoginToken } from '../api/getLoginToken';
 
-const useGetLoginToken = () => {
+interface useGetLoginTokenProps {
+  loginToken: string;
+  setLoginToken: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const useGetLoginToken = (props: useGetLoginTokenProps) => {
+  const { setLoginToken } = props;
+
   const navigate = useNavigate();
 
   const mutation = useMutation({
@@ -16,7 +23,7 @@ const useGetLoginToken = () => {
       navigate('/error');
     },
     onSuccess: (data) => {
-      return data.access_token;
+      setLoginToken(data.access_token);
     },
   });
   return mutation;

--- a/src/Login/hooks/usePostLoginToken.ts
+++ b/src/Login/hooks/usePostLoginToken.ts
@@ -1,4 +1,3 @@
-import { AxiosError } from 'axios';
 import { useMutation } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
@@ -27,8 +26,7 @@ const usePostLoginToken = () => {
         }
       }
     },
-    onError: (error: AxiosError) => {
-      console.error('usePostLoginToken', error.response?.data);
+    onError: () => {
       navigate('/error');
     },
   });

--- a/src/Login/hooks/usePostLoginToken.ts
+++ b/src/Login/hooks/usePostLoginToken.ts
@@ -14,7 +14,7 @@ const usePostLoginToken = () => {
     onSuccess: (data) => {
       const { tokenDto, nickname } = data;
 
-      if (nickname === null || nickname === '') {
+      if (nickname === null) {
         navigate('/register', { state: { token: tokenDto.accessToken } });
       } else {
         window.localStorage.setItem('token', tokenDto.accessToken);

--- a/src/Login/hooks/usePostLoginToken.ts
+++ b/src/Login/hooks/usePostLoginToken.ts
@@ -1,0 +1,38 @@
+import { AxiosError } from 'axios';
+import { useMutation } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { postLoginToken } from '../api/postLoginToken';
+
+const usePostLoginToken = () => {
+  const navigate = useNavigate();
+
+  const mutation = useMutation({
+    mutationFn: async (token: string) => {
+      return await postLoginToken(token);
+    },
+    onSuccess: (data) => {
+      const { tokenDto, nickname } = data;
+
+      if (nickname === null || nickname === '') {
+        navigate('/register', { state: { token: tokenDto.accessToken } });
+      } else {
+        window.localStorage.setItem('token', tokenDto.accessToken);
+        window.localStorage.setItem('nickname', nickname);
+
+        if (sessionStorage.getItem('url') === '') {
+          navigate('/', { state: { step: 1 } });
+        } else {
+          navigate(-4);
+        }
+      }
+    },
+    onError: (error: AxiosError) => {
+      console.error('usePostLoginToken', error.response?.data);
+      navigate('/error');
+    },
+  });
+  return mutation;
+};
+
+export default usePostLoginToken;

--- a/src/Register/hooks/usePatchNickname.ts
+++ b/src/Register/hooks/usePatchNickname.ts
@@ -34,7 +34,6 @@ const usePatchNickname = (props: usePatchNicknameProps) => {
         setIsValid('space');
         setIsActive(false);
       } else {
-        console.error('usePatchNickname', err.response?.data);
         navigate('/error');
       }
     },


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #229 

## ✅ 작업 내용

- [x] postLoginToken 쿼리 적용
- [x] getLoginToken 쿼리 적용

## 📌 이슈 사항
컴포넌트에서 쿼리 적용한 useGetLoginToken을 아무리 호출해도 리턴값이 넘어오지 않더라구요 ..? (useGetLoginToken이 onSuccess일 때, 카카오 서버에서 받아온 response 안에 있는 access_toekn을 리턴해주려 했습니다!) 그래서 좀 더 공부를 해오니 리턴값을 넘겨줄 수 없다 ..! 라는 것을 새롭게 알게 되어서 `loginToken` 이라는 state를 새롭게 만들게 되었습니다..! 이 방법이 최선일까요? 🥺