### PR TITLE
[ Detail ] 사진을 배경으로 하는 레큐 노트 클릭 시, 모달에서 사진 줌되는 이슈

### DIFF
--- a/src/Detail/components/LecueNoteModal/LecueNoteModal.style.ts
+++ b/src/Detail/components/LecueNoteModal/LecueNoteModal.style.ts
@@ -32,7 +32,7 @@ export const LecueNoteModalWrapper = styled.div<{
       return `background: url(${noteBackground})`;
     }
   }};
-  background-size: cover;
+  background-size: 31.1rem 35.8rem;
   color: ${({ noteTextColor }) => {
     return noteTextColor;
   }};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #230 

## ✅ 작업 내용

- [x] 사진을 배경으로 하는 레큐 노트 클릭 시, 모달에서 사진 줌되는 이슈 해결

## 📌 이슈 사항
- background-size 속성을 cover에서 컴포넌트 width, height 사이즈로 맞춰주었습니다.
