### PR TITLE
[ Register ] 타입 / 닉네임 유효성 검사 로직 분리

### DIFF
--- a/src/Register/components/NicknameInput/index.tsx
+++ b/src/Register/components/NicknameInput/index.tsx
@@ -1,47 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { isValidState } from '../../page';
+import { handleChangeInput } from '../../hooks/useCheckNickname';
+import { NicknameInputProps } from '../../types/registerTypes';
 import * as S from './NicknameInput.style';
-
-interface NicknameInputProps {
-  nickname: string;
-  setNickname: React.Dispatch<React.SetStateAction<string>>;
-  setIsActive: React.Dispatch<React.SetStateAction<boolean>>;
-  setIsValid: React.Dispatch<React.SetStateAction<isValidState>>;
-  isValid: string;
-}
 
 function NicknameInput(props: NicknameInputProps) {
   const { nickname, setNickname, setIsActive, isValid, setIsValid } = props;
 
   const [wordCnt, setWordCnt] = useState(0);
-
-  /** 영어, 숫자, 문자, 공백인지 체크하는 정규식 함수 */
-  const checkInputRange = (str: string) => {
-    const regExp = /[ㄱ-ㅎㅏ-ㅣ가-힣0-9a-zA-Z\s]/g;
-    return regExp.test(str) || str.length === 0;
-  };
-
-  /** 8자 이하 & 한글, 영어, 숫자만 입력 가능하도록 & 첫번째 글자는 공백 불가능 체크 함수*/
-  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const input = e.target.value;
-
-    if (
-      e.target.value.length <= 8 &&
-      checkInputRange(input[input.length - 1])
-    ) {
-      if (e.target.value === ' ') {
-        setNickname('');
-        setWordCnt(0);
-      } else {
-        setNickname(e.target.value);
-        setWordCnt(e.target.value.length);
-      }
-      setIsValid('valid');
-    } else {
-      e.target.value.length > 8 ? setIsValid('valid') : setIsValid('special');
-    }
-  };
 
   useEffect(() => {
     wordCnt >= 2 ? setIsActive(true) : setIsActive(false);
@@ -55,7 +21,9 @@ function NicknameInput(props: NicknameInputProps) {
           type="text"
           value={nickname}
           placeholder="닉네임을 입력해주세요."
-          onChange={handleChangeInput}
+          onChange={(e) => {
+            handleChangeInput({ setNickname, setWordCnt, setIsValid, e });
+          }}
         />
         <S.WordCount>({wordCnt}/8)</S.WordCount>
       </S.InputContainer>

--- a/src/Register/components/NicknameInput/index.tsx
+++ b/src/Register/components/NicknameInput/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { handleChangeInput } from '../../hooks/useCheckNickname';
 import { NicknameInputProps } from '../../types/registerTypes';
+import handleChangeInput from '../../utils/handleCheckInput';
 import * as S from './NicknameInput.style';
 
 function NicknameInput(props: NicknameInputProps) {

--- a/src/Register/components/NicknameInput/index.tsx
+++ b/src/Register/components/NicknameInput/index.tsx
@@ -5,12 +5,22 @@ import handleChangeInput from '../../utils/handleCheckInput';
 import * as S from './NicknameInput.style';
 
 function NicknameInput(props: NicknameInputProps) {
-  const { nickname, setNickname, setIsActive, isValid, setIsValid } = props;
+  const {
+    nickname,
+    isValid,
+    handleSetNickname,
+    handleSetIsActive,
+    handleSetIsValid,
+  } = props;
 
   const [wordCnt, setWordCnt] = useState(0);
 
+  const handleSetWordCnt = (wordCnt: number) => {
+    setWordCnt(wordCnt);
+  };
+
   useEffect(() => {
-    wordCnt >= 2 ? setIsActive(true) : setIsActive(false);
+    wordCnt >= 2 ? handleSetIsActive(true) : handleSetIsActive(false);
   }, [wordCnt]);
 
   return (
@@ -22,7 +32,12 @@ function NicknameInput(props: NicknameInputProps) {
           value={nickname}
           placeholder="닉네임을 입력해주세요."
           onChange={(e) => {
-            handleChangeInput({ setNickname, setWordCnt, setIsValid, e });
+            handleChangeInput({
+              handleSetNickname,
+              handleSetWordCnt,
+              handleSetIsValid,
+              e,
+            });
           }}
         />
         <S.WordCount>({wordCnt}/8)</S.WordCount>

--- a/src/Register/components/SubmitButton/index.tsx
+++ b/src/Register/components/SubmitButton/index.tsx
@@ -1,25 +1,17 @@
 import Button from '../../../components/common/Button';
 import usePatchNickname from '../../hooks/usePatchNickname';
-import { isValidState } from '../../page';
+import { SubmitButtonProps } from '../../types/registerTypes';
 import * as S from './SubmitButton.style';
 
-type SubmitButtonProps = {
-  isActive: boolean;
-  token: string;
-  nickname: string;
-  setIsValid: React.Dispatch<React.SetStateAction<isValidState>>;
-  isValid: string;
-  setIsActive: React.Dispatch<React.SetStateAction<boolean>>;
-};
+function SubmitButton(props: SubmitButtonProps) {
+  const { isActive, token, nickname, setIsValid, setIsActive } = props;
 
-function SubmitButton({
-  isActive,
-  token,
-  nickname,
-  setIsValid,
-  setIsActive,
-}: SubmitButtonProps) {
-  const patchMutation = usePatchNickname({ setIsValid, setIsActive, token, nickname });
+  const patchMutation = usePatchNickname({
+    setIsValid,
+    setIsActive,
+    token,
+    nickname,
+  });
 
   const handelClickSubmitBtn = (token: string, nickname: string) => {
     const patchNickname = nickname.trim();

--- a/src/Register/components/SubmitButton/index.tsx
+++ b/src/Register/components/SubmitButton/index.tsx
@@ -4,11 +4,12 @@ import { SubmitButtonProps } from '../../types/registerTypes';
 import * as S from './SubmitButton.style';
 
 function SubmitButton(props: SubmitButtonProps) {
-  const { isActive, token, nickname, setIsValid, setIsActive } = props;
+  const { isActive, token, nickname, handleSetIsValid, handleSetIsActive } =
+    props;
 
   const patchMutation = usePatchNickname({
-    setIsValid,
-    setIsActive,
+    handleSetIsValid,
+    handleSetIsActive,
     token,
     nickname,
   });

--- a/src/Register/hooks/useCheckNickname.ts
+++ b/src/Register/hooks/useCheckNickname.ts
@@ -1,0 +1,27 @@
+import { CheckNicknameProps } from '../types/registerTypes';
+
+/** 영어, 숫자, 문자, 공백인지 체크하는 정규식 함수 */
+const checkInputRange = (str: string) => {
+  const regExp = /[ㄱ-ㅎㅏ-ㅣ가-힣0-9a-zA-Z\s]/g;
+  return regExp.test(str) || str.length === 0;
+};
+
+/** 8자 이하 & 한글, 영어, 숫자만 입력 가능하도록 & 첫번째 글자는 공백 불가능 체크 함수*/
+export const handleChangeInput = (props: CheckNicknameProps) => {
+  const { setNickname, setWordCnt, setIsValid, e } = props;
+
+  const input = e.target.value;
+
+  if (e.target.value.length <= 8 && checkInputRange(input[input.length - 1])) {
+    if (e.target.value === ' ') {
+      setNickname('');
+      setWordCnt(0);
+    } else {
+      setNickname(e.target.value);
+      setWordCnt(e.target.value.length);
+    }
+    setIsValid('valid');
+  } else {
+    e.target.value.length > 8 ? setIsValid('valid') : setIsValid('special');
+  }
+};

--- a/src/Register/hooks/usePatchNickname.ts
+++ b/src/Register/hooks/usePatchNickname.ts
@@ -3,7 +3,7 @@ import { useMutation } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { patchNickname } from '../api/patchNickname';
-import { isValidState } from '../page';
+import { isValidState } from '../types/registerTypes';
 
 interface patchNicknameProps {
   token: string;
@@ -11,12 +11,12 @@ interface patchNicknameProps {
 }
 
 interface usePatchNicknameProps extends patchNicknameProps {
-  setIsValid: React.Dispatch<React.SetStateAction<isValidState>>;
-  setIsActive: React.Dispatch<React.SetStateAction<boolean>>;
+  handleSetIsActive: (isActive: boolean) => void;
+  handleSetIsValid: (isValid: isValidState) => void;
 }
 
 const usePatchNickname = (props: usePatchNicknameProps) => {
-  const { setIsValid, setIsActive, token, nickname } = props;
+  const { handleSetIsValid, handleSetIsActive, token, nickname } = props;
 
   const navigate = useNavigate();
 
@@ -28,11 +28,11 @@ const usePatchNickname = (props: usePatchNicknameProps) => {
       const code = err.response?.status;
       if (code === 409) {
         // 닉네임 중복코드 : 409
-        setIsValid('duplicate');
-        setIsActive(false);
+        handleSetIsValid('duplicate');
+        handleSetIsActive(false);
       } else if (code === 400) {
-        setIsValid('space');
-        setIsActive(false);
+        handleSetIsValid('space');
+        handleSetIsActive(false);
       } else {
         console.error('usePatchNickname', err.response?.data);
         navigate('/error');

--- a/src/Register/hooks/usePatchNickname.ts
+++ b/src/Register/hooks/usePatchNickname.ts
@@ -27,7 +27,6 @@ const usePatchNickname = (props: usePatchNicknameProps) => {
         handleSetIsValid('space');
         handleSetIsActive(false);
       } else {
-        console.error('usePatchNickname', err.response?.data);
         navigate('/error');
       }
     },

--- a/src/Register/hooks/usePatchNickname.ts
+++ b/src/Register/hooks/usePatchNickname.ts
@@ -3,17 +3,10 @@ import { useMutation } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { patchNickname } from '../api/patchNickname';
-import { isValidState } from '../types/registerTypes';
-
-interface patchNicknameProps {
-  token: string;
-  nickname: string;
-}
-
-interface usePatchNicknameProps extends patchNicknameProps {
-  handleSetIsActive: (isActive: boolean) => void;
-  handleSetIsValid: (isValid: isValidState) => void;
-}
+import {
+  patchNicknameProps,
+  usePatchNicknameProps,
+} from '../types/registerTypes';
 
 const usePatchNickname = (props: usePatchNicknameProps) => {
   const { handleSetIsValid, handleSetIsActive, token, nickname } = props;

--- a/src/Register/page/index.tsx
+++ b/src/Register/page/index.tsx
@@ -4,9 +4,8 @@ import { useLocation } from 'react-router-dom';
 import NicknameInput from '../components/NicknameInput';
 import RegisterLogo from '../components/RegisterLogo';
 import SubmitButton from '../components/SubmitButton';
+import { isValidState } from '../types/registerTypes';
 import * as S from './Register.style';
-
-export type isValidState = 'valid' | 'special' | 'duplicate' | 'space';
 
 function Register() {
   const [isActive, setIsActive] = useState(false);

--- a/src/Register/page/index.tsx
+++ b/src/Register/page/index.tsx
@@ -13,26 +13,37 @@ function Register() {
   const [isValid, setIsValid] = useState<isValidState>('valid');
 
   const location = useLocation();
-
   const { token } = location.state && location.state;
+
+  const handleSetNickname = (nickname: string) => {
+    setNickname(nickname);
+  };
+
+  const handleSetIsValid = (isValid: isValidState) => {
+    setIsValid(isValid);
+  };
+
+  const handleSetIsActive = (isActive: boolean) => {
+    setIsActive(isActive);
+  };
 
   return (
     <S.Wrapper>
       <RegisterLogo />
       <NicknameInput
-        setIsActive={setIsActive}
+        handleSetIsActive={handleSetIsActive}
         nickname={nickname}
-        setNickname={setNickname}
+        handleSetNickname={handleSetNickname}
         isValid={isValid}
-        setIsValid={setIsValid}
+        handleSetIsValid={handleSetIsValid}
       />
       <SubmitButton
         isActive={isActive}
         nickname={nickname}
         token={token}
-        setIsValid={setIsValid}
+        handleSetIsValid={handleSetIsValid}
         isValid={isValid}
-        setIsActive={setIsActive}
+        handleSetIsActive={handleSetIsActive}
       />
     </S.Wrapper>
   );

--- a/src/Register/types/registerTypes.ts
+++ b/src/Register/types/registerTypes.ts
@@ -23,3 +23,13 @@ export interface CheckNicknameProps {
   handleSetIsValid: (isValid: isValidState) => void;
   e: React.ChangeEvent<HTMLInputElement>;
 }
+
+export interface patchNicknameProps {
+  token: string;
+  nickname: string;
+}
+
+export interface usePatchNicknameProps extends patchNicknameProps {
+  handleSetIsActive: (isActive: boolean) => void;
+  handleSetIsValid: (isValid: isValidState) => void;
+}

--- a/src/Register/types/registerTypes.ts
+++ b/src/Register/types/registerTypes.ts
@@ -3,9 +3,9 @@ export type isValidState = 'valid' | 'special' | 'duplicate' | 'space';
 export interface NicknameInputProps {
   nickname: string;
   isValid: string;
-  setNickname: React.Dispatch<React.SetStateAction<string>>;
-  setIsActive: React.Dispatch<React.SetStateAction<boolean>>;
-  setIsValid: React.Dispatch<React.SetStateAction<isValidState>>;
+  handleSetNickname: (nickname: string) => void;
+  handleSetIsActive: (isActive: boolean) => void;
+  handleSetIsValid: (isValid: isValidState) => void;
 }
 
 export type SubmitButtonProps = {
@@ -13,13 +13,13 @@ export type SubmitButtonProps = {
   nickname: string;
   isActive: boolean;
   isValid: string;
-  setIsValid: React.Dispatch<React.SetStateAction<isValidState>>;
-  setIsActive: React.Dispatch<React.SetStateAction<boolean>>;
+  handleSetIsValid: (isValid: isValidState) => void;
+  handleSetIsActive: (isActive: boolean) => void;
 };
 
 export interface CheckNicknameProps {
-  setNickname: React.Dispatch<React.SetStateAction<string>>;
-  setWordCnt: React.Dispatch<React.SetStateAction<number>>;
-  setIsValid: React.Dispatch<React.SetStateAction<isValidState>>;
+  handleSetNickname: (nickname: string) => void;
+  handleSetWordCnt: (wordCnt: number) => void;
+  handleSetIsValid: (isValid: isValidState) => void;
   e: React.ChangeEvent<HTMLInputElement>;
 }

--- a/src/Register/types/registerTypes.ts
+++ b/src/Register/types/registerTypes.ts
@@ -1,0 +1,25 @@
+export type isValidState = 'valid' | 'special' | 'duplicate' | 'space';
+
+export interface NicknameInputProps {
+  nickname: string;
+  isValid: string;
+  setNickname: React.Dispatch<React.SetStateAction<string>>;
+  setIsActive: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsValid: React.Dispatch<React.SetStateAction<isValidState>>;
+}
+
+export type SubmitButtonProps = {
+  token: string;
+  nickname: string;
+  isActive: boolean;
+  isValid: string;
+  setIsValid: React.Dispatch<React.SetStateAction<isValidState>>;
+  setIsActive: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export interface CheckNicknameProps {
+  setNickname: React.Dispatch<React.SetStateAction<string>>;
+  setWordCnt: React.Dispatch<React.SetStateAction<number>>;
+  setIsValid: React.Dispatch<React.SetStateAction<isValidState>>;
+  e: React.ChangeEvent<HTMLInputElement>;
+}

--- a/src/Register/types/registerTypes.ts
+++ b/src/Register/types/registerTypes.ts
@@ -8,14 +8,10 @@ export interface NicknameInputProps {
   handleSetIsValid: (isValid: isValidState) => void;
 }
 
-export type SubmitButtonProps = {
+export interface SubmitButtonProps extends NicknameInputProps {
   token: string;
-  nickname: string;
   isActive: boolean;
-  isValid: string;
-  handleSetIsValid: (isValid: isValidState) => void;
-  handleSetIsActive: (isActive: boolean) => void;
-};
+}
 
 export interface CheckNicknameProps {
   handleSetNickname: (nickname: string) => void;

--- a/src/Register/utils/checkInputRange.ts
+++ b/src/Register/utils/checkInputRange.ts
@@ -1,0 +1,7 @@
+/** 영어, 숫자, 문자, 공백인지 체크하는 정규식 함수 */
+const checkInputRange = (str: string) => {
+  const regExp = /[ㄱ-ㅎㅏ-ㅣ가-힣0-9a-zA-Z\s]/g;
+  return regExp.test(str) || str.length === 0;
+};
+
+export default checkInputRange;

--- a/src/Register/utils/handleCheckInput.ts
+++ b/src/Register/utils/handleCheckInput.ts
@@ -1,13 +1,8 @@
 import { CheckNicknameProps } from '../types/registerTypes';
-
-/** 영어, 숫자, 문자, 공백인지 체크하는 정규식 함수 */
-const checkInputRange = (str: string) => {
-  const regExp = /[ㄱ-ㅎㅏ-ㅣ가-힣0-9a-zA-Z\s]/g;
-  return regExp.test(str) || str.length === 0;
-};
+import checkInputRange from './checkInputRange';
 
 /** 8자 이하 & 한글, 영어, 숫자만 입력 가능하도록 & 첫번째 글자는 공백 불가능 체크 함수*/
-export const handleChangeInput = (props: CheckNicknameProps) => {
+const handleChangeInput = (props: CheckNicknameProps) => {
   const { setNickname, setWordCnt, setIsValid, e } = props;
 
   const input = e.target.value;
@@ -25,3 +20,5 @@ export const handleChangeInput = (props: CheckNicknameProps) => {
     e.target.value.length > 8 ? setIsValid('valid') : setIsValid('special');
   }
 };
+
+export default handleChangeInput;

--- a/src/Register/utils/handleCheckInput.ts
+++ b/src/Register/utils/handleCheckInput.ts
@@ -3,21 +3,23 @@ import checkInputRange from './checkInputRange';
 
 /** 8자 이하 & 한글, 영어, 숫자만 입력 가능하도록 & 첫번째 글자는 공백 불가능 체크 함수*/
 const handleChangeInput = (props: CheckNicknameProps) => {
-  const { setNickname, setWordCnt, setIsValid, e } = props;
+  const { handleSetNickname, handleSetWordCnt, handleSetIsValid, e } = props;
 
   const input = e.target.value;
 
   if (e.target.value.length <= 8 && checkInputRange(input[input.length - 1])) {
     if (e.target.value === ' ') {
-      setNickname('');
-      setWordCnt(0);
+      handleSetNickname('');
+      handleSetWordCnt(0);
     } else {
-      setNickname(e.target.value);
-      setWordCnt(e.target.value.length);
+      handleSetNickname(e.target.value);
+      handleSetWordCnt(e.target.value.length);
     }
-    setIsValid('valid');
+    handleSetIsValid('valid');
   } else {
-    e.target.value.length > 8 ? setIsValid('valid') : setIsValid('special');
+    e.target.value.length > 8
+      ? handleSetIsValid('valid')
+      : handleSetIsValid('special');
   }
 };
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #223 

## ✅ 작업 내용

- [x] 닉네임 입력 페이지(Register) 코드 리팩토링 및 최적화
- [x] Register 페이지 타입 분리
- [x] 닉네임 유효성 검사 로직 분리 

## 📌 이슈 사항
닉네임 유효성 검사하는 함수들을 별도의 hook으로 분리해보았습니다..! 이게 맞는지 확신은 서지 않지만 닉네임을 입력받는 input 컴포넌트 파일에 있는 유효성 검사 함수들을 따로 분리하고, 해당 컴포넌트는 닉네임을 입력 받는 단일 역할을 주는게 좀 더 맞다고 생각했기 때문이죠 ..