### PR TITLE
[ StickerAttach ] 스티커 overflow 수정

### DIFF
--- a/src/Detail/components/ZigZagView/ZigZagView.style.ts
+++ b/src/Detail/components/ZigZagView/ZigZagView.style.ts
@@ -4,6 +4,7 @@ export const ZigZagViewWrapper = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   position: relative;
+  overflow: hidden;
 
   width: 34.2rem;
   padding: 1rem 0 2rem;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #219 #221
-
## ✅ 작업 내용

- [x] 스크린 길이보다 넓은 스티커는 보이지 않게 합니다.

## 📌 이슈 사항
- 가장 좋은 방법은 배열에서 삭제시키는 것일 것 같은데 현재 각 스티커 하나씩을 post하고, 서버측에서 배열에 담아주고 있어서 서버랑 논의 해보아야할 것 같습니다. 
- 처음부터 height값을 제대로 못 읽어오는 문제는 충돌 문제가 있을 것 같아 https://github.com/Team-Lecue/Lecue-Client/pull/225 해당 PR에서 진행했습니다!
