### PR TITLE
[ HOTFIX ] 스티커 post 불가 버그

### DIFF
--- a/src/Detail/components/LecueNoteListContainer/index.tsx
+++ b/src/Detail/components/LecueNoteListContainer/index.tsx
@@ -71,7 +71,7 @@ function LecueNoteListContainer(props: LecueNoteListContainerProps) {
         setHeightFromBottom(fullHeight - stickerState.positionY);
       }
     }
-  }, [scrollRef]);
+  }, [fullHeight, stickerState.positionY, scrollRef]);
 
   useEffect(() => {
     if (location.state) {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## ✅ 작업 내용

- [x] 바닥으로 부터의 높이 값을 null로 받아오면서 스티커 부착 (post)가 안되는 이슈 발생 => dependency Arrray에 현재 y값 위치와 전체 너비 담아 계산 바로 할 수 있게 수정 함. 
