### PR TITLE
[ CreateNote ] 이미지 확장자(heic)에 따라 업로드 안되는 이슈 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.6.5",
     "eslint-plugin-react": "^7.33.2",
     "grapheme-splitter": "^1.0.4",
+    "heic2any": "^0.0.4",
     "lottie-react": "^2.4.0",
     "postcss": "^8.4.33",
     "postcss-styled-syntax": "^0.6.3",

--- a/src/LecueNote/components/SelectColor/index.tsx
+++ b/src/LecueNote/components/SelectColor/index.tsx
@@ -18,6 +18,7 @@ function SelectColor({
   handleColorFn,
   handleIconFn,
   selectedFile,
+  handleIsLoading,
 }: SelectColorProps) {
   const { textColor, background, category } = lecueNoteState;
 
@@ -48,6 +49,7 @@ function SelectColor({
         selectedFile={selectedFile}
         handleFn={handleColorFn}
         handleIconFn={handleIconFn}
+        handleIsLoading={handleIsLoading}
       />
     </S.Wrapper>
   );

--- a/src/LecueNote/components/SelectColor/index.tsx
+++ b/src/LecueNote/components/SelectColor/index.tsx
@@ -20,7 +20,7 @@ function SelectColor({
   selectedFile,
   handleIsLoading,
 }: SelectColorProps) {
-  const { textColor, background, category } = lecueNoteState;
+  const { textColor, background, category, contents } = lecueNoteState;
 
   return (
     <S.Wrapper>
@@ -44,6 +44,7 @@ function SelectColor({
         isIconClicked={isIconClicked}
         colorChart={category === '텍스트색' ? TEXT_COLOR_CHART : BG_COLOR_CHART}
         state={category === '텍스트색' ? textColor : background}
+        contents={contents}
         handleTransformImgFile={handleTransformImgFile}
         presignedUrlDispatch={presignedUrlDispatch}
         selectedFile={selectedFile}

--- a/src/LecueNote/components/ShowColorChart/index.tsx
+++ b/src/LecueNote/components/ShowColorChart/index.tsx
@@ -25,7 +25,7 @@ function ShowColorChart({
   useGetPresignedUrl({ presignedUrlDispatch });
 
   const handleChangeContents = () => {
-    localStorage.setItem('noteContents', contents ? contents : '');
+    sessionStorage.setItem('noteContents', contents ? contents : '');
   };
 
   const handleReaderOnloadend = (reader: FileReader, file: File) => {
@@ -39,10 +39,7 @@ function ShowColorChart({
     if (fileInput && fileInput.files && fileInput.files.length > 0) {
       const file = fileInput.files[0];
 
-      if (
-        file.name.split('.')[1] === 'heic' ||
-        file.name.split('.')[1] === 'HEIC'
-      ) {
+      if (file.name.split('.')[1].toUpperCase() === 'HEIC') {
         handleClickHeicToJpg({
           file: file,
           handleTransformImgFile,

--- a/src/LecueNote/components/ShowColorChart/index.tsx
+++ b/src/LecueNote/components/ShowColorChart/index.tsx
@@ -13,6 +13,7 @@ function ShowColorChart({
   isIconClicked,
   colorChart,
   state,
+  contents,
   handleTransformImgFile,
   presignedUrlDispatch,
   selectedFile,
@@ -22,6 +23,10 @@ function ShowColorChart({
 }: ShowColorChartProps) {
   const imgRef = useRef<HTMLInputElement | null>(null);
   useGetPresignedUrl({ presignedUrlDispatch });
+
+  const handleChangeContents = () => {
+    localStorage.setItem('noteContents', contents ? contents : '');
+  };
 
   const handleReaderOnloadend = (reader: FileReader, file: File) => {
     handleTransformImgFile(reader);
@@ -76,6 +81,7 @@ function ShowColorChart({
           <S.IconWrapper
             onClick={() => {
               handleIconFn();
+              handleChangeContents();
               imgRef.current?.click();
             }}
             $isIconClicked={isIconClicked}

--- a/src/LecueNote/components/ShowColorChart/index.tsx
+++ b/src/LecueNote/components/ShowColorChart/index.tsx
@@ -1,4 +1,3 @@
-import heic2any from 'heic2any';
 import { useRef } from 'react';
 
 import { IcCameraSmall } from '../../../assets';
@@ -7,6 +6,7 @@ import useGetPresignedUrl from '../../hooks/useGetPresignedUrl';
 import { ShowColorChartProps } from '../../type/lecueNoteType';
 import handleClickFiletoBinary from '../../util/handleClickFiletoBinary';
 import handleClickFiletoString from '../../util/handleClickFiletoString';
+import handleClickHeicToJpg from '../../util/handleClickHeicToJpg';
 import * as S from './ShowColorChart.style';
 
 function ShowColorChart({
@@ -18,6 +18,7 @@ function ShowColorChart({
   selectedFile,
   handleFn,
   handleIconFn,
+  handleIsLoading,
 }: ShowColorChartProps) {
   const imgRef = useRef<HTMLInputElement | null>(null);
   useGetPresignedUrl({ presignedUrlDispatch });
@@ -37,33 +38,12 @@ function ShowColorChart({
         file.name.split('.')[1] === 'heic' ||
         file.name.split('.')[1] === 'HEIC'
       ) {
-        // 'heic' 확장자인 경우에만 처리
-        heic2any({ blob: file, toType: 'image/jpeg' }).then(
-          function (resultBlob) {
-            // 변환된 Blob을 사용하여 새로운 File 생성
-            const jpg = new File(
-              Array.isArray(resultBlob) ? resultBlob : [resultBlob],
-              file.name.split('.')[0] + '.jpg',
-              { type: 'image/jpeg', lastModified: new Date().getTime() },
-            );
-
-            // reader1: 파일을 base64로 읽어서 업로드
-            const reader1 = new FileReader();
-            handleClickFiletoString({
-              file: jpg,
-              reader: reader1,
-              handleTransformImgFile,
-            });
-
-            // reader2: 파일을 ArrayBuffer로 읽어서 PUT 요청 수행
-            const reader2 = new FileReader();
-            handleClickFiletoBinary({
-              file: jpg,
-              reader: reader2,
-              handleReaderOnloadend,
-            });
-          },
-        );
+        handleClickHeicToJpg({
+          file: file,
+          handleTransformImgFile,
+          handleReaderOnloadend,
+          handleIsLoading,
+        });
       } else {
         const reader1 = new FileReader();
         handleClickFiletoString({

--- a/src/LecueNote/components/ShowColorChart/index.tsx
+++ b/src/LecueNote/components/ShowColorChart/index.tsx
@@ -1,3 +1,4 @@
+import heic2any from 'heic2any';
 import { useRef } from 'react';
 
 import { IcCameraSmall } from '../../../assets';
@@ -25,23 +26,59 @@ function ShowColorChart({
     if (fileInput && fileInput.files && fileInput.files.length > 0) {
       const file = fileInput.files[0];
 
-      // reader1: 파일을 base64로 읽어서 업로드
-      const reader1 = new FileReader();
-      reader1.readAsDataURL(file);
-      reader1.onloadend = () => {
-        if (reader1.result !== null) {
-          handleTransformImgFile(reader1.result as string);
-        }
-      };
+      if (
+        file.name.split('.')[1] === 'heic' ||
+        file.name.split('.')[1] === 'HEIC'
+      ) {
+        // 'heic' 확장자인 경우에만 처리
+        heic2any({ blob: file, toType: 'image/jpeg' }).then(
+          function (resultBlob) {
+            // 변환된 Blob을 사용하여 새로운 File 생성
+            const jpg = new File(
+              Array.isArray(resultBlob) ? resultBlob : [resultBlob],
+              file.name.split('.')[0] + '.jpg',
+              { type: 'image/jpeg', lastModified: new Date().getTime() },
+            );
+            
+            // reader1: 파일을 base64로 읽어서 업로드
+            const reader1 = new FileReader();
 
-      // reader2: 파일을 ArrayBuffer로 읽어서 PUT 요청 수행
-      const reader2 = new FileReader();
-      reader2.readAsArrayBuffer(file);
-      // reader1의 비동기 작업이 완료된 후 수행(onloadend() 활용)
-      reader2.onloadend = () => {
-        handleTransformImgFile(reader2);
-        selectedFile(file);
-      };
+            reader1.readAsDataURL(jpg);
+            reader1.onloadend = () => {
+              if (reader1.result !== null) {
+                handleTransformImgFile(reader1.result as string);
+              }
+            };
+
+            // reader2: 파일을 ArrayBuffer로 읽어서 PUT 요청 수행
+            const reader2 = new FileReader();
+            reader2.readAsArrayBuffer(jpg);
+            // reader1의 비동기 작업이 완료된 후 수행(onloadend() 활용)
+            reader2.onloadend = () => {
+              handleTransformImgFile(reader2);
+              selectedFile(jpg);
+            };
+          },
+        );
+      } else {
+        // reader1: 파일을 base64로 읽어서 업로드
+        const reader1 = new FileReader();
+        reader1.readAsDataURL(file);
+        reader1.onloadend = () => {
+          if (reader1.result !== null) {
+            handleTransformImgFile(reader1.result as string);
+          }
+        };
+
+        // reader2: 파일을 ArrayBuffer로 읽어서 PUT 요청 수행
+        const reader2 = new FileReader();
+        reader2.readAsArrayBuffer(file);
+        // reader1의 비동기 작업이 완료된 후 수행(onloadend() 활용)
+        reader2.onloadend = () => {
+          handleTransformImgFile(reader2);
+          selectedFile(file);
+        };
+      }
     }
   };
 
@@ -51,7 +88,7 @@ function ShowColorChart({
         <>
           <S.Input
             type="file"
-            accept="image/*"
+            accept="image/*, image/heic"
             onChange={handleImageUpload}
             ref={imgRef}
           />

--- a/src/LecueNote/components/ShowColorChart/index.tsx
+++ b/src/LecueNote/components/ShowColorChart/index.tsx
@@ -5,6 +5,8 @@ import { IcCameraSmall } from '../../../assets';
 import { BG_COLOR_CHART } from '../../constants/colorChart';
 import useGetPresignedUrl from '../../hooks/useGetPresignedUrl';
 import { ShowColorChartProps } from '../../type/lecueNoteType';
+import handleClickFiletoBinary from '../../util/handleClickFiletoBinary';
+import handleClickFiletoString from '../../util/handleClickFiletoString';
 import * as S from './ShowColorChart.style';
 
 function ShowColorChart({
@@ -19,6 +21,11 @@ function ShowColorChart({
 }: ShowColorChartProps) {
   const imgRef = useRef<HTMLInputElement | null>(null);
   useGetPresignedUrl({ presignedUrlDispatch });
+
+  const handleReaderOnloadend = (reader: FileReader, file: File) => {
+    handleTransformImgFile(reader);
+    selectedFile(file);
+  };
 
   const handleImageUpload = () => {
     const fileInput = imgRef.current;
@@ -39,45 +46,38 @@ function ShowColorChart({
               file.name.split('.')[0] + '.jpg',
               { type: 'image/jpeg', lastModified: new Date().getTime() },
             );
-            
+
             // reader1: 파일을 base64로 읽어서 업로드
             const reader1 = new FileReader();
-
-            reader1.readAsDataURL(jpg);
-            reader1.onloadend = () => {
-              if (reader1.result !== null) {
-                handleTransformImgFile(reader1.result as string);
-              }
-            };
+            handleClickFiletoString({
+              file: jpg,
+              reader: reader1,
+              handleTransformImgFile,
+            });
 
             // reader2: 파일을 ArrayBuffer로 읽어서 PUT 요청 수행
             const reader2 = new FileReader();
-            reader2.readAsArrayBuffer(jpg);
-            // reader1의 비동기 작업이 완료된 후 수행(onloadend() 활용)
-            reader2.onloadend = () => {
-              handleTransformImgFile(reader2);
-              selectedFile(jpg);
-            };
+            handleClickFiletoBinary({
+              file: jpg,
+              reader: reader2,
+              handleReaderOnloadend,
+            });
           },
         );
       } else {
-        // reader1: 파일을 base64로 읽어서 업로드
         const reader1 = new FileReader();
-        reader1.readAsDataURL(file);
-        reader1.onloadend = () => {
-          if (reader1.result !== null) {
-            handleTransformImgFile(reader1.result as string);
-          }
-        };
+        handleClickFiletoString({
+          file: file,
+          reader: reader1,
+          handleTransformImgFile,
+        });
 
-        // reader2: 파일을 ArrayBuffer로 읽어서 PUT 요청 수행
         const reader2 = new FileReader();
-        reader2.readAsArrayBuffer(file);
-        // reader1의 비동기 작업이 완료된 후 수행(onloadend() 활용)
-        reader2.onloadend = () => {
-          handleTransformImgFile(reader2);
-          selectedFile(file);
-        };
+        handleClickFiletoBinary({
+          file: file,
+          reader: reader2,
+          handleReaderOnloadend,
+        });
       }
     }
   };

--- a/src/LecueNote/components/WriteNote/NoteLoading/NoteLoading.style.ts
+++ b/src/LecueNote/components/WriteNote/NoteLoading/NoteLoading.style.ts
@@ -4,6 +4,9 @@ export const LoadingWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
 
   width: 100%;
   height: 100%;

--- a/src/LecueNote/components/WriteNote/NoteLoading/NoteLoading.style.ts
+++ b/src/LecueNote/components/WriteNote/NoteLoading/NoteLoading.style.ts
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+export const LoadingWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 100%;
+
+  border: 0.6rem;
+  background-color: ${({ theme }) => theme.colors.background};
+`;
+
+export const LottieWrapper = styled.div`
+  width: 10rem;
+  height: 10rem;
+`;

--- a/src/LecueNote/components/WriteNote/NoteLoading/index.tsx
+++ b/src/LecueNote/components/WriteNote/NoteLoading/index.tsx
@@ -1,9 +1,17 @@
 import Lottie from 'lottie-react';
+import { useEffect } from 'react';
 
 import animationData from '../../../../../src/assets/lottie/spiner 120.json';
 import * as S from './NoteLoading.style';
 
-const NoteLoading = () => {
+interface NoteLoadingProps {
+  handleResetPrevImg: () => void;
+}
+const NoteLoading = ({ handleResetPrevImg }: NoteLoadingProps) => {
+  useEffect(() => {
+    handleResetPrevImg();
+  }, []);
+
   return (
     <S.LoadingWrapper>
       <S.LottieWrapper>

--- a/src/LecueNote/components/WriteNote/NoteLoading/index.tsx
+++ b/src/LecueNote/components/WriteNote/NoteLoading/index.tsx
@@ -1,0 +1,16 @@
+import Lottie from 'lottie-react';
+
+import animationData from '../../../../../src/assets/lottie/spiner 120.json';
+import * as S from './NoteLoading.style';
+
+const NoteLoading = () => {
+  return (
+    <S.LoadingWrapper>
+      <S.LottieWrapper>
+        <Lottie animationData={animationData} />
+      </S.LottieWrapper>
+    </S.LoadingWrapper>
+  );
+};
+
+export default NoteLoading;

--- a/src/LecueNote/components/WriteNote/WriteNote.style.ts
+++ b/src/LecueNote/components/WriteNote/WriteNote.style.ts
@@ -14,6 +14,7 @@ export const LecueNote = styled.article<{
 }>`
   display: flex;
   flex-direction: column;
+  position: relative;
 
   width: 100%;
   height: calc(100dvh - 33.2rem);

--- a/src/LecueNote/components/WriteNote/WriteNote.style.ts
+++ b/src/LecueNote/components/WriteNote/WriteNote.style.ts
@@ -85,3 +85,19 @@ export const Notice = styled.p`
 
   ${({ theme }) => theme.fonts.Caption1_R_12};
 `;
+
+export const LoadingWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 100%;
+
+  background-color: transparent;
+`;
+
+export const LottieWrapper = styled.div`
+  width: 10rem;
+  height: 10rem;
+`;

--- a/src/LecueNote/components/WriteNote/WriteNote.style.ts
+++ b/src/LecueNote/components/WriteNote/WriteNote.style.ts
@@ -85,19 +85,3 @@ export const Notice = styled.p`
 
   ${({ theme }) => theme.fonts.Caption1_R_12};
 `;
-
-export const LoadingWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  width: 100%;
-  height: 100%;
-
-  background-color: transparent;
-`;
-
-export const LottieWrapper = styled.div`
-  width: 10rem;
-  height: 10rem;
-`;

--- a/src/LecueNote/components/WriteNote/index.tsx
+++ b/src/LecueNote/components/WriteNote/index.tsx
@@ -1,10 +1,13 @@
 import GraphemeSplitter from 'grapheme-splitter';
+import Lottie from 'lottie-react';
 import { useEffect, useState } from 'react';
 
+import animationData from '../../../../src/assets/lottie/spiner 120.json';
 import { WriteNoteProps } from '../../type/lecueNoteType';
 import * as S from './WriteNote.style';
 
 function WriteNote({
+  isLoading,
   lecueNoteState,
   imgFile,
   isIconClicked,
@@ -30,18 +33,30 @@ function WriteNote({
         $isIconClicked={isIconClicked}
         $imgFile={imgFile}
       >
-        <S.Nickname $textColor={textColor}>{nickname}</S.Nickname>
-        <S.Contents
-          $textColor={textColor}
-          onChange={handleChangeFn}
-          placeholder="최애에게 마음을 표현해보세요"
-        />
-        <S.BottomContentsWrapper>
-          <S.Date>
-            {dateArr[0]}.{dateArr[1]}.{dateArr[2]}
-          </S.Date>
-          <S.Counter>({split.splitGraphemes(contents).length}/1000)</S.Counter>
-        </S.BottomContentsWrapper>
+        {isLoading ? (
+          <S.LoadingWrapper>
+            <S.LottieWrapper>
+              <Lottie animationData={animationData} />
+            </S.LottieWrapper>
+          </S.LoadingWrapper>
+        ) : (
+          <>
+            <S.Nickname $textColor={textColor}>{nickname}</S.Nickname>
+            <S.Contents
+              $textColor={textColor}
+              onChange={handleChangeFn}
+              placeholder="최애에게 마음을 표현해보세요"
+            />
+            <S.BottomContentsWrapper>
+              <S.Date>
+                {dateArr[0]}.{dateArr[1]}.{dateArr[2]}
+              </S.Date>
+              <S.Counter>
+                ({split.splitGraphemes(contents).length}/1000)
+              </S.Counter>
+            </S.BottomContentsWrapper>
+          </>
+        )}
       </S.LecueNote>
       <S.Notice>*욕설/비속어는 자동 필터링됩니다.</S.Notice>
     </S.Wrapper>

--- a/src/LecueNote/components/WriteNote/index.tsx
+++ b/src/LecueNote/components/WriteNote/index.tsx
@@ -12,6 +12,7 @@ function WriteNote({
   isIconClicked,
   contents,
   handleChangeFn,
+  handleResetPrevImg,
 }: WriteNoteProps) {
   const nickname = localStorage.getItem('nickname');
   const { textColor, background } = lecueNoteState;
@@ -33,7 +34,7 @@ function WriteNote({
         $imgFile={imgFile}
       >
         {isLoading ? (
-          <NoteLoading />
+          <NoteLoading handleResetPrevImg={handleResetPrevImg} />
         ) : (
           <>
             <S.Nickname $textColor={textColor}>{nickname}</S.Nickname>

--- a/src/LecueNote/components/WriteNote/index.tsx
+++ b/src/LecueNote/components/WriteNote/index.tsx
@@ -33,26 +33,20 @@ function WriteNote({
         $isIconClicked={isIconClicked}
         $imgFile={imgFile}
       >
-        {isLoading ? (
-          <NoteLoading handleResetPrevImg={handleResetPrevImg} />
-        ) : (
-          <>
-            <S.Nickname $textColor={textColor}>{nickname}</S.Nickname>
-            <S.Contents
-              $textColor={textColor}
-              onChange={handleChangeFn}
-              placeholder="최애에게 마음을 표현해보세요"
-            />
-            <S.BottomContentsWrapper>
-              <S.Date>
-                {dateArr[0]}.{dateArr[1]}.{dateArr[2]}
-              </S.Date>
-              <S.Counter>
-                ({split.splitGraphemes(contents).length}/1000)
-              </S.Counter>
-            </S.BottomContentsWrapper>
-          </>
-        )}
+        {isLoading && <NoteLoading handleResetPrevImg={handleResetPrevImg} />}
+
+        <S.Nickname $textColor={textColor}>{nickname}</S.Nickname>
+        <S.Contents
+          $textColor={textColor}
+          onChange={handleChangeFn}
+          placeholder="최애에게 마음을 표현해보세요"
+        />
+        <S.BottomContentsWrapper>
+          <S.Date>
+            {dateArr[0]}.{dateArr[1]}.{dateArr[2]}
+          </S.Date>
+          <S.Counter>({split.splitGraphemes(contents).length}/1000)</S.Counter>
+        </S.BottomContentsWrapper>
       </S.LecueNote>
       <S.Notice>*욕설/비속어는 자동 필터링됩니다.</S.Notice>
     </S.Wrapper>

--- a/src/LecueNote/components/WriteNote/index.tsx
+++ b/src/LecueNote/components/WriteNote/index.tsx
@@ -1,9 +1,8 @@
 import GraphemeSplitter from 'grapheme-splitter';
-import Lottie from 'lottie-react';
 import { useEffect, useState } from 'react';
 
-import animationData from '../../../../src/assets/lottie/spiner 120.json';
 import { WriteNoteProps } from '../../type/lecueNoteType';
+import NoteLoading from './NoteLoading';
 import * as S from './WriteNote.style';
 
 function WriteNote({
@@ -34,11 +33,7 @@ function WriteNote({
         $imgFile={imgFile}
       >
         {isLoading ? (
-          <S.LoadingWrapper>
-            <S.LottieWrapper>
-              <Lottie animationData={animationData} />
-            </S.LottieWrapper>
-          </S.LoadingWrapper>
+          <NoteLoading />
         ) : (
           <>
             <S.Nickname $textColor={textColor}>{nickname}</S.Nickname>

--- a/src/LecueNote/page/LeceuNotePage/index.tsx
+++ b/src/LecueNote/page/LeceuNotePage/index.tsx
@@ -23,17 +23,17 @@ function LecueNotePage() {
   const location = useLocation();
   const putMutation = usePutPresignedUrl();
   const postMutation = usePostLecueNote();
+  const noteContents = localStorage.getItem('noteContents');
   const { bookId } = location.state || {};
 
   const [modalOn, setModalOn] = useState(false);
   const [escapeModal, setEscapeModal] = useState(false);
-
   const [isLoading, setIsLoading] = useState(false);
 
   const [lecueNoteState, dispatch] = useReducer(reducer, {
     presignedUrl: '',
     filename: BG_COLOR_CHART[0],
-    contents: '',
+    contents: noteContents !== null ? noteContents : '',
     category: CATEGORY[0],
     textColor: TEXT_COLOR_CHART[0],
     background: BG_COLOR_CHART[0],
@@ -99,6 +99,8 @@ function LecueNotePage() {
       isIconClicked: lecueNoteState.isIconClicked,
       bookId: bookId,
     });
+
+    localStorage.setItem('noteContents', '');
   };
 
   return putMutation.isLoading || postMutation.isLoading ? (
@@ -115,7 +117,10 @@ function LecueNotePage() {
 
       {escapeModal && (
         <CommonModal
-          handleFn={() => navigate(-1)}
+          handleFn={() => {
+            navigate(-1);
+            localStorage.setItem('noteContents', '');
+          }}
           category="note_escape"
           setModalOn={setEscapeModal}
         />

--- a/src/LecueNote/page/LeceuNotePage/index.tsx
+++ b/src/LecueNote/page/LeceuNotePage/index.tsx
@@ -30,10 +30,6 @@ function LecueNotePage() {
 
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleIsLoading = (booleanStatus: boolean) => {
-    setIsLoading(booleanStatus);
-  };
-
   const [lecueNoteState, dispatch] = useReducer(reducer, {
     presignedUrl: '',
     filename: BG_COLOR_CHART[0],
@@ -46,6 +42,14 @@ function LecueNotePage() {
     imgToStr: '',
     imgToBinary: new FileReader(),
   });
+
+  const handleIsLoading = (booleanStatus: boolean) => {
+    setIsLoading(booleanStatus);
+  };
+
+  const handleResetPrevImg = () => {
+    dispatch({ type: 'RESET_PREV_IMG' });
+  };
 
   const handleChangeContents = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     dispatch({ type: 'SET_CONTENTS', contents: e.target.value });
@@ -123,12 +127,13 @@ function LecueNotePage() {
 
       <S.CreateNote>
         <WriteNote
-        isLoading={isLoading}
+          isLoading={isLoading}
           imgFile={lecueNoteState.imgToStr}
           isIconClicked={lecueNoteState.isIconClicked}
           lecueNoteState={lecueNoteState}
           contents={lecueNoteState.contents}
           handleChangeFn={handleChangeContents}
+          handleResetPrevImg={handleResetPrevImg}
         />
         <SelectColor
           isIconClicked={lecueNoteState.isIconClicked}

--- a/src/LecueNote/page/LeceuNotePage/index.tsx
+++ b/src/LecueNote/page/LeceuNotePage/index.tsx
@@ -23,7 +23,7 @@ function LecueNotePage() {
   const location = useLocation();
   const putMutation = usePutPresignedUrl();
   const postMutation = usePostLecueNote();
-  const noteContents = localStorage.getItem('noteContents');
+  const noteContents = sessionStorage.getItem('noteContents');
   const { bookId } = location.state || {};
 
   const [modalOn, setModalOn] = useState(false);
@@ -100,7 +100,7 @@ function LecueNotePage() {
       bookId: bookId,
     });
 
-    localStorage.setItem('noteContents', '');
+    sessionStorage.setItem('noteContents', '');
   };
 
   return putMutation.isLoading || postMutation.isLoading ? (
@@ -119,7 +119,7 @@ function LecueNotePage() {
         <CommonModal
           handleFn={() => {
             navigate(-1);
-            localStorage.setItem('noteContents', '');
+            sessionStorage.setItem('noteContents', '');
           }}
           category="note_escape"
           setModalOn={setEscapeModal}

--- a/src/LecueNote/page/LeceuNotePage/index.tsx
+++ b/src/LecueNote/page/LeceuNotePage/index.tsx
@@ -28,6 +28,12 @@ function LecueNotePage() {
   const [modalOn, setModalOn] = useState(false);
   const [escapeModal, setEscapeModal] = useState(false);
 
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleIsLoading = (booleanStatus: boolean) => {
+    setIsLoading(booleanStatus);
+  };
+
   const [lecueNoteState, dispatch] = useReducer(reducer, {
     presignedUrl: '',
     filename: BG_COLOR_CHART[0],
@@ -117,6 +123,7 @@ function LecueNotePage() {
 
       <S.CreateNote>
         <WriteNote
+        isLoading={isLoading}
           imgFile={lecueNoteState.imgToStr}
           isIconClicked={lecueNoteState.isIconClicked}
           lecueNoteState={lecueNoteState}
@@ -139,6 +146,7 @@ function LecueNotePage() {
           }
           handleColorFn={handleClickedColorBtn}
           handleIconFn={() => dispatch({ type: 'CLICKED_IMG_ICON' })}
+          handleIsLoading={handleIsLoading}
         />
       </S.CreateNote>
 

--- a/src/LecueNote/reducer/lecueNoteReducer.ts
+++ b/src/LecueNote/reducer/lecueNoteReducer.ts
@@ -46,6 +46,9 @@ export const reducer = (state: State, action: Action): State => {
     case 'IMG_TO_BINARY':
       return { ...state, imgToBinary: action.imgFile };
 
+    case 'RESET_PREV_IMG':
+      return { ...state, imgToStr: '' };
+
     default:
       throw new Error('Unhandled action');
   }

--- a/src/LecueNote/type/lecueNoteType.ts
+++ b/src/LecueNote/type/lecueNoteType.ts
@@ -4,6 +4,7 @@ export interface SelectColorProps {
     textColor: string;
     background: string;
     category?: string;
+    contents?: string;
   };
   selectedFile: (file: File) => void;
   presignedUrlDispatch: React.Dispatch<{
@@ -24,6 +25,7 @@ export interface ShowColorChartProps {
   isIconClicked: boolean;
   colorChart: string[];
   state: string;
+  contents?: string;
   handleTransformImgFile: (file: string | FileReader) => void;
   selectedFile: (file: File) => void;
   handleFn: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;

--- a/src/LecueNote/type/lecueNoteType.ts
+++ b/src/LecueNote/type/lecueNoteType.ts
@@ -17,6 +17,7 @@ export interface SelectColorProps {
   handleColorFn: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   handleIconFn: () => void;
   handleTransformImgFile: (file: string | FileReader) => void;
+  handleIsLoading: (status: boolean) => void;
 }
 
 export interface ShowColorChartProps {
@@ -32,9 +33,11 @@ export interface ShowColorChartProps {
     presignedUrl: string;
     filename: string;
   }>;
+  handleIsLoading: (status: boolean) => void;
 }
 
 export interface WriteNoteProps {
+  isLoading: boolean;
   imgFile: string;
   isIconClicked: boolean;
   lecueNoteState: {

--- a/src/LecueNote/type/lecueNoteType.ts
+++ b/src/LecueNote/type/lecueNoteType.ts
@@ -47,6 +47,7 @@ export interface WriteNoteProps {
   };
   contents: string;
   handleChangeFn: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  handleResetPrevImg: () => void;
 }
 
 export interface FooterProps {

--- a/src/LecueNote/type/reducerType.ts
+++ b/src/LecueNote/type/reducerType.ts
@@ -21,4 +21,5 @@ export type Action =
   | { type: 'CLICKED_IMG_ICON' }
   | { type: 'NOT_CLICKED_IMG_ICON' }
   | { type: 'IMG_TO_STR'; imgFile: string }
-  | { type: 'IMG_TO_BINARY'; imgFile: FileReader };
+  | { type: 'IMG_TO_BINARY'; imgFile: FileReader }
+  | { type: 'RESET_PREV_IMG'; };

--- a/src/LecueNote/util/handleClickFiletoBinary.ts
+++ b/src/LecueNote/util/handleClickFiletoBinary.ts
@@ -1,0 +1,19 @@
+interface handleClickFiletoBinaryProps {
+  file: File;
+  reader: FileReader;
+  handleReaderOnloadend: (reader: FileReader, file: File) => void;
+}
+
+const handleClickFiletoBinary = ({
+  file,
+  reader,
+  handleReaderOnloadend,
+}: handleClickFiletoBinaryProps) => {
+  reader.readAsArrayBuffer(file);
+  // reader1의 비동기 작업이 완료된 후 수행(onloadend() 활용)
+  reader.onloadend = () => {
+    handleReaderOnloadend(reader, file);
+  };
+};
+
+export default handleClickFiletoBinary;

--- a/src/LecueNote/util/handleClickFiletoString.ts
+++ b/src/LecueNote/util/handleClickFiletoString.ts
@@ -1,0 +1,20 @@
+interface handleClickFiletoStringProps {
+  file: File;
+  reader: FileReader;
+  handleTransformImgFile: (file: string | FileReader) => void;
+}
+
+const handleClickFiletoString = ({
+  file,
+  reader,
+  handleTransformImgFile,
+}: handleClickFiletoStringProps) => {
+  reader.readAsDataURL(file);
+  reader.onloadend = () => {
+    if (reader.result !== null) {
+      handleTransformImgFile(reader.result as string);
+    }
+  };
+};
+
+export default handleClickFiletoString;

--- a/src/LecueNote/util/handleClickHeicToJpg.ts
+++ b/src/LecueNote/util/handleClickHeicToJpg.ts
@@ -1,0 +1,49 @@
+import heic2any from 'heic2any';
+
+import handleClickFiletoBinary from './handleClickFiletoBinary';
+import handleClickFiletoString from './handleClickFiletoString';
+
+interface handleClickHeicToJpgProps {
+  file: File;
+  handleTransformImgFile: (file: string | FileReader) => void;
+  handleReaderOnloadend: (reader: FileReader, file: File) => void;
+  handleIsLoading: (status: boolean) => void;
+}
+
+const handleClickHeicToJpg = ({
+  file,
+  handleTransformImgFile,
+  handleReaderOnloadend,
+  handleIsLoading,
+}: handleClickHeicToJpgProps) => {
+  handleIsLoading(true);
+
+  heic2any({ blob: file, toType: 'image/jpeg' })
+    .then(function (resultBlob) {
+      // 변환된 Blob을 사용하여 새로운 File 생성
+      const jpg = new File(
+        Array.isArray(resultBlob) ? resultBlob : [resultBlob],
+        file.name.split('.')[0] + '.jpg',
+        { type: 'image/jpeg', lastModified: new Date().getTime() },
+      );
+
+      // reader1: 파일을 base64로 읽어서 업로드
+      const reader1 = new FileReader();
+      handleClickFiletoString({
+        file: jpg,
+        reader: reader1,
+        handleTransformImgFile,
+      });
+
+      // reader2: 파일을 ArrayBuffer로 읽어서 PUT 요청 수행
+      const reader2 = new FileReader();
+      handleClickFiletoBinary({
+        file: jpg,
+        reader: reader2,
+        handleReaderOnloadend,
+      });
+    })
+    .finally(() => handleIsLoading(false));
+};
+
+export default handleClickHeicToJpg;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2228,6 +2228,11 @@ hasown@^2.0.0:
   dependencies:
     function-bind "^1.1.2"
 
+heic2any@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/heic2any/-/heic2any-0.0.4.tgz#eddb8e6fec53c8583a6e18b65069bb5e8d19028a"
+  integrity sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==
+
 hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #220 
## ✅ 작업 내용

- [x] heic 파일 선택 가능하도록 수정
- [x] heic -> jpeg 파일로 형변환 기능 구현
- [x] 형변환 과정에서 로딩 발생 시, 로딩 스피너 띄워줌
- [x] 파일 형변환 -> 로딩 -> 변환 완료 과정을 거치더라도 이전에 입력한 노트 내용이 사라지지 않도록 localStorage 활용하여 구현

## 📌 이슈 사항
- `heic2any` 라이브러리를 활용하여 heic/ HEIC -> jpeg 파일로 변환해주었습니다.
- `isLoading` state를 만들어서 로딩 처리를 해주었습니다.
- `localStorage`를 활용하여 heic 파일을 업로드 하더라도 화면 상의 이전 내용이 유지되도록 구현했습니다.

## ✍ 궁금한 것
- 형변환 과정에서도 이미 시간이 좀 걸리고 localStorage에 저장된 노트 내용을 불러오는 과정에서도 시간이 걸려서 로딩 과정이 꽤 긴 편인데요, 이걸 어떻게 하면 해결할 수 있을까요?
- 테스트 해보니 heic 파일이 아이폰으로 넘어오면 heif로 바껴서 딱히 형변환 없이도 잘 올라가긴 합니다만,, 위의 문제를 해결할 법한 뾰족한 수가 떠오르지 않네용 흑흑
  - 아이폰의 heif 파일 -> 데탑으로 넘어오면 heic로 바뀜.
