### PR TITLE
[ Home ] 로그인 여부에 따른 분기처리

### DIFF
--- a/src/Home/page/index.tsx
+++ b/src/Home/page/index.tsx
@@ -8,6 +8,7 @@ import useGetLecueBook from '../hooks/useGetLecueBook';
 import * as S from './Home.style';
 
 function Home({ handleStep }: StepProps) {
+  const token = localStorage.getItem('token');
   const { isLoading, data } = useGetLecueBook();
 
   useEffect(() => {
@@ -20,7 +21,7 @@ function Home({ handleStep }: StepProps) {
     <S.Wrapper>
       <NavigateLecueBook />
       {/* 서버 api 나오면 즐겨찾기 data props로 넘겨주는 부분 추가할 예정 */}
-      <LecueBookList title="즐겨찾기한 레큐북" />
+      {token && <LecueBookList title="즐겨찾기한 레큐북" />}
       <LecueBookList title="인기 레큐북 구경하기" data={data.data} />
     </S.Wrapper>
   );


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #256 

## ✅ 작업 내용

- [x] 로그인 O -> 즐겨찾기 + 인기 레큐북 동시에 띄워주기
- [x] 로그인 X -> 인기 레큐북만 띄워주기

## 📸 스크린샷 / GIF / Link

https://github.com/Team-Lecue/Lecue-Client/assets/80264647/ff9b90e0-cff4-4cc2-aea3-93d678aebc59



## 📌 이슈 사항
- 로컬스토리지에 엑세스토큰이 저장되어 있는지 여부에 따라 보여지는 컴포넌트가 다르게 구현했습니다.
- 로컬스토리지에 저장된 엑세스토큰이 있는 경우에만, 즐겨찾기 컴포넌트를 띄워줍니다.

