### PR TITLE
[ Home ] 즐겨찾기 아이콘 클릭 시 즐겨찾기에서 삭제

### DIFF
--- a/src/Home/components/LecueBookList/LecueBookList.style.ts
+++ b/src/Home/components/LecueBookList/LecueBookList.style.ts
@@ -38,11 +38,17 @@ export const LecueBook = styled.li`
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  position: relative;
 
   width: 100%;
-  height: 14rem;
 
   cursor: pointer;
+`;
+
+export const IconWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0.1rem;
 `;
 
 export const BookImage = styled.img`

--- a/src/Home/components/LecueBookList/index.tsx
+++ b/src/Home/components/LecueBookList/index.tsx
@@ -24,6 +24,15 @@ function LecueBookList({ title, data }: LecueBookListProps) {
     navigate(`/lecue-book/${uuid}`);
   };
 
+  const handleClickFavoriteIcon = (bookId: number) => {
+    // api가 나오면 서버 통신 코드로 변경할 예정! (현재는 임시로 구현해둠)
+    const clickedBookMark = document.getElementById(`${bookId}`);
+
+    if (clickedBookMark) {
+      clickedBookMark.style.display = 'none';
+    }
+  };
+
   return (
     <S.LecueBookListWrapper>
       <S.Title>{title}</S.Title>
@@ -33,10 +42,16 @@ function LecueBookList({ title, data }: LecueBookListProps) {
             data.map((book: BookProps) => (
               <S.LecueBook
                 key={book.bookId}
+                id={`${book.bookId}`}
                 onClick={() => handleClickLecueBook(book.bookUuid)}
               >
                 {isBookmark && (
-                  <S.IconWrapper>
+                  <S.IconWrapper
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleClickFavoriteIcon(book.bookId);
+                    }}
+                  >
                     <IcHomeFavorite />
                   </S.IconWrapper>
                 )}

--- a/src/Home/components/LecueBookList/index.tsx
+++ b/src/Home/components/LecueBookList/index.tsx
@@ -40,22 +40,20 @@ function LecueBookList({ title, data }: LecueBookListProps) {
         <S.LecueBookList>
           {data &&
             data.map((book: BookProps) => (
-              <S.LecueBook
-                key={book.bookId}
-                id={`${book.bookId}`}
-                onClick={() => handleClickLecueBook(book.bookUuid)}
-              >
+              <S.LecueBook key={book.bookId} id={`${book.bookId}`}>
                 {isBookmark && (
                   <S.IconWrapper
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleClickFavoriteIcon(book.bookId);
-                    }}
+                    onClick={() => handleClickFavoriteIcon(book.bookId)}
                   >
                     <IcHomeFavorite />
                   </S.IconWrapper>
                 )}
-                <S.BookImage src={book.favoriteImage} alt="레큐북-이미지" />
+
+                <S.BookImage
+                  src={book.favoriteImage}
+                  alt="레큐북-이미지"
+                  onClick={() => handleClickLecueBook(book.bookUuid)}
+                />
                 <S.BookTitle>{book.favoriteName}</S.BookTitle>
               </S.LecueBook>
             ))}

--- a/src/Home/components/LecueBookList/index.tsx
+++ b/src/Home/components/LecueBookList/index.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router';
 
+import { IcHomeFavorite } from '../../../assets';
 import NoBookmarkList from '../NoBookmarkList';
 import * as S from './LecueBookList.style';
 
@@ -17,6 +18,7 @@ interface LecueBookListProps {
 
 function LecueBookList({ title, data }: LecueBookListProps) {
   const navigate = useNavigate();
+  const isBookmark = title.includes('즐겨찾기');
 
   const handleClickLecueBook = (uuid: string) => {
     navigate(`/lecue-book/${uuid}`);
@@ -33,6 +35,11 @@ function LecueBookList({ title, data }: LecueBookListProps) {
                 key={book.bookId}
                 onClick={() => handleClickLecueBook(book.bookUuid)}
               >
+                {isBookmark && (
+                  <S.IconWrapper>
+                    <IcHomeFavorite />
+                  </S.IconWrapper>
+                )}
                 <S.BookImage src={book.favoriteImage} alt="레큐북-이미지" />
                 <S.BookTitle>{book.favoriteName}</S.BookTitle>
               </S.LecueBook>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #255 

## ✅ 작업 내용

- [x] 즐겨찾기 아이콘 추가
- [x] 즐겨찾기 아이콘 클릭 이벤트 구현

## 📸 스크린샷 / GIF / Link

https://github.com/Team-Lecue/Lecue-Client/assets/80264647/19cc7ba7-e9eb-480f-a5a5-c696563b7b3a


## 📌 이슈 사항
- 아직 즐겨찾기 리스트를 불러오는 api가 나오지 않아서, 임시로 인기 레큐북 데이터를 즐겨찾기 컴포넌트의 데이터로 넣어서 작업했습니다.
- 즐겨찾기 아이콘 클릭 시, delete 메소드를 통해 기존 즐겨찾기 리스트에 있는 데이터를 지울 것 같습니다.
   - 아직 즐겨찾기 삭제 관련 api도 나오지 않은 상태라, 즐겨찾기 아이콘 클릭 시 해당 레큐북의 `display: none` 처리 해두었습니다.
   - 이 과정에서 IconWrapper의 액션 핸들러보다 LecueBook의 액션핸들러가 먼저 동작하는 이슈가 있어서 `e.stopPropagation()` 한 줄 추가해줬습니다.
   - 앞서 구현한 IconWrapper의 액션 핸들러 관련 코드는 api가 나오면 모두 서버통신 코드로 바꿔줄 예정입니다 !!

