### PR TITLE
[ Mypage ] Header를 포함한 Mypage 기본 프레임 구현

### DIFF
--- a/src/Mypage/page/Mypage.style.ts
+++ b/src/Mypage/page/Mypage.style.ts
@@ -12,6 +12,7 @@ export const Wrapper = styled.article`
 `;
 
 export const MyPageBodyWrapper = styled.div`
+  width: 100%;
   padding: 0 1.6rem;
   margin-top: 5.4rem;
 `;

--- a/src/Mypage/page/Mypage.style.ts
+++ b/src/Mypage/page/Mypage.style.ts
@@ -11,14 +11,6 @@ export const Wrapper = styled.article`
   background-color: ${({ theme }) => theme.colors.background};
 `;
 
-export const InfoWrapper = styled.div`
-  width: 100%;
-  padding: 0 0.95rem 1rem;
+export const MyPageBodyWrapper = styled.div`
   margin-top: 5.4rem;
-`;
-
-export const ListWrapper = styled.div`
-  width: 100%;
-  height: calc(100dvh - 14.6rem);
-  padding: 0 1rem 1rem;
 `;

--- a/src/Mypage/page/Mypage.style.ts
+++ b/src/Mypage/page/Mypage.style.ts
@@ -12,5 +12,6 @@ export const Wrapper = styled.article`
 `;
 
 export const MyPageBodyWrapper = styled.div`
+  padding: 0 1.6rem;
   margin-top: 5.4rem;
 `;

--- a/src/Mypage/page/index.tsx
+++ b/src/Mypage/page/index.tsx
@@ -1,7 +1,5 @@
 import Header from '../../components/common/Header';
 import LoadingPage from '../../components/common/LoadingPage';
-import LecueList from '../components/LecueList';
-import Nickname from '../components/Nickname';
 import useDeleteMyBook from '../hooks/useDeleteMyBook';
 import useGetMyBookList from '../hooks/useGetMyBookList';
 import useGetMyNickName from '../hooks/useGetMyNickname';
@@ -17,13 +15,8 @@ function Mypage() {
     <LoadingPage />
   ) : (
     <S.Wrapper>
-      <Header headerTitle={'내 기록'} />
-      <S.InfoWrapper>
-        <Nickname />
-      </S.InfoWrapper>
-      <S.ListWrapper>
-        <LecueList />
-      </S.ListWrapper>
+      <Header headerTitle={'마이페이지'} />
+      <S.MyPageBodyWrapper></S.MyPageBodyWrapper>
     </S.Wrapper>
   );
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #263 

## ✅ 작업 내용

- [x] Header를 포함한 Mypage 기본 프레임 구현

## 📸 스크린샷 / GIF / Link
<img width="400" alt="image" src="https://github.com/Team-Lecue/Lecue-Client/assets/60962533/4fc0af6b-a32d-4980-9a6f-466f7d7181a3">

## 📌 이슈 사항
MypageBodyWrapper 안에 갈아낄 컴포넌트들 렌더시키면 될 것 같습니다아!!
기존 컴포넌트들 재사용 가능성이 있어 일단은 삭제 안 하고 남겨뒀습니다~!
