### PR TITLE
[ Mypage ] 내 기록보기 진입 페이지 뷰 구현

### DIFF
--- a/src/Mypage/components/HistoryEnterView/HistoryEnterView.style.ts
+++ b/src/Mypage/components/HistoryEnterView/HistoryEnterView.style.ts
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  padding: 2.9rem 1.6rem;
+  gap: 1.2rem;
+`;
+
+export const Tab = styled.li`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 13rem;
+
+  padding: 0 3rem;
+  border-radius: 0.2rem;
+
+  background-color: ${({ theme }) => theme.colors.LG};
+  cursor: pointer;
+
+  ${({ theme }) => theme.fonts.Title1_SB_16}
+  color: ${({ theme }) => theme.colors.BG}
+`;

--- a/src/Mypage/components/HistoryEnterView/index.tsx
+++ b/src/Mypage/components/HistoryEnterView/index.tsx
@@ -1,0 +1,13 @@
+import * as S from './HistoryEnterView.style';
+
+function HistoryEnterView() {
+  return (
+    <S.Wrapper>
+      <S.Tab>즐겨찾기 한 레큐북</S.Tab>
+      <S.Tab>내가 만든 레큐북</S.Tab>
+      <S.Tab>내가 남긴 레큐노트</S.Tab>
+    </S.Wrapper>
+  );
+}
+
+export default HistoryEnterView;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #262 

## ✅ 작업 내용

- [x] 마이페이지 > 내 기록보기 진입 페이지 퍼블리싱

## 📸 스크린샷 / GIF / Link
<img width="379" alt="스크린샷 2024-03-14 오후 6 03 30" src="https://github.com/Team-Lecue/Lecue-Client/assets/108219121/17a8466d-18e2-43b2-92e3-96ffbe35d80e">

## 📌 이슈 사항
추후에 일러스트가 들어간다고 합니다.. 일러스트가 들어가면 뷰에 또 변화가 있다고 하니 일단은 피그마에 있는대로 만들어둘게용..! 각 요소를 눌렀을 때의 컴포넌트 교체는 정우가 할 겁니다..! 페이지 라우팅은 이전PR(#266) 머지하고 적용해둘게요!
## ✍ 궁금한 것
XXXX
