### PR TITLE
[ Mypage ] 닉네임 수정 페이지 접근 시, 처음 글자 수 정상적으로 반영되도록 수정

### DIFF
--- a/src/EditNickname/components/NicknameInput/index.tsx
+++ b/src/EditNickname/components/NicknameInput/index.tsx
@@ -10,8 +10,8 @@ function NicknameInput({
   handleSetNickname,
   handleSetIsValid,
 }: NicknameInputProps) {
-  const [wordCnt, setWordCnt] = useState(0);
   const currentNickname: string = localStorage.getItem('nickname') || '';
+  const [wordCnt, setWordCnt] = useState(currentNickname.length);
 
   const handleSetWordCnt = (wordCnt: number) => {
     setWordCnt(wordCnt);


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #312 

## ✅ 작업 내용

- [ ] 닉네임 수정 페이지 접근 시, 처음 글자 수가 0으로 표시되는 이슈 해결

## 📸 스크린샷 / GIF / Link


https://github.com/Team-Lecue/Lecue-Client/assets/60962533/0b6dcead-ddb1-4735-8a7f-cfbb2c05f226





## 📌 이슈 사항
wordCnt state의 초기값을 0에서 초기 닉네임의 길이로 수정해주어 해결했습니다!!

```ts
const currentNickname: string = localStorage.getItem('nickname') || '';
const [wordCnt, setWordCnt] = useState(currentNickname.length);
```

닉네임 수정 후 닉네임 깜빡임 현상도 해결해보겠습니다...!!