### PR TITLE
[ Mypage ] 내가 만든 레큐북, 즐겨찾기한 레큐북 싱크 안 맞음

### DIFF
--- a/src/History/components/MyLecueBook/index.tsx
+++ b/src/History/components/MyLecueBook/index.tsx
@@ -48,13 +48,11 @@ function MyLecueBook(props: LecueBookProps) {
     bookId: number,
   ) => {
     event.stopPropagation();
-    isFavorite
-      ? deleteFavoriteMutation.mutate(bookId)
-      : postFavoriteMutation.mutate(bookId);
+    isFavorite ? deleteFavoriteMutation(bookId) : postFavoriteMutation(bookId);
   };
 
   const handleDeleteBookFn = () => {
-    deleteBookMutation.mutate(bookId);
+    deleteBookMutation(bookId);
   };
 
   useEffect(() => {

--- a/src/History/components/MyLecueBook/index.tsx
+++ b/src/History/components/MyLecueBook/index.tsx
@@ -24,9 +24,9 @@ function MyLecueBook(props: LecueBookProps) {
 
   const navigate = useNavigate();
 
-  const deleteMutation = useDeleteMyBook();
-  const FavoritePostMutation = usePostFavorite();
-  const FavoriteDeleteMutation = useDeleteFavorite('myLecueBook');
+  const deleteBookMutation = useDeleteMyBook();
+  const postFavoriteMutation = usePostFavorite();
+  const deleteFavoriteMutation = useDeleteFavorite('myLecueBook');
 
   const convertNoteCount = (noteNum: number) => {
     setNoteCount(noteNum.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ','));
@@ -48,15 +48,13 @@ function MyLecueBook(props: LecueBookProps) {
     bookId: number,
   ) => {
     event.stopPropagation();
-    if (isFavorite) {
-      FavoriteDeleteMutation.mutate(bookId);
-    } else {
-      FavoritePostMutation.mutate(bookId);
-    }
+    isFavorite
+      ? deleteFavoriteMutation.mutate(bookId)
+      : postFavoriteMutation.mutate(bookId);
   };
 
-  const handleFn = () => {
-    deleteMutation.mutate(bookId);
+  const handleDeleteBookFn = () => {
+    deleteBookMutation.mutate(bookId);
   };
 
   useEffect(() => {
@@ -98,7 +96,7 @@ function MyLecueBook(props: LecueBookProps) {
         <CommonModal
           category="book_delete"
           setModalOn={setModalOn}
-          handleFn={handleFn}
+          handleFn={handleDeleteBookFn}
         />
       )}
     </S.Wrapper>

--- a/src/History/components/MyLecueBook/index.tsx
+++ b/src/History/components/MyLecueBook/index.tsx
@@ -21,13 +21,12 @@ function MyLecueBook(props: LecueBookProps) {
   } = props;
   const [noteCount, setNoteCount] = useState('');
   const [modalOn, setModalOn] = useState(false);
-  const [favorite, setFavorite] = useState(isFavorite);
 
   const navigate = useNavigate();
 
   const deleteMutation = useDeleteMyBook();
   const FavoritePostMutation = usePostFavorite();
-  const FavoriteDeleteMutation = useDeleteFavorite('mypage');
+  const FavoriteDeleteMutation = useDeleteFavorite('myLecueBook');
 
   const convertNoteCount = (noteNum: number) => {
     setNoteCount(noteNum.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ','));
@@ -49,12 +48,10 @@ function MyLecueBook(props: LecueBookProps) {
     bookId: number,
   ) => {
     event.stopPropagation();
-    if (favorite) {
+    if (isFavorite) {
       FavoriteDeleteMutation.mutate(bookId);
-      setFavorite(false);
     } else {
       FavoritePostMutation.mutate(bookId);
-      setFavorite(true);
     }
   };
 
@@ -64,7 +61,7 @@ function MyLecueBook(props: LecueBookProps) {
 
   useEffect(() => {
     convertNoteCount(noteNum);
-  }, [favorite]);
+  }, []);
 
   return (
     <S.Wrapper>
@@ -81,7 +78,7 @@ function MyLecueBook(props: LecueBookProps) {
               handleClickFavoriteBtn(event, bookId);
             }}
           >
-            {favorite ? <IcStar /> : <IcStarDefault />}
+            {isFavorite ? <IcStar /> : <IcStarDefault />}
           </S.Favorite>
         </S.Header>
         <S.Title>{title}</S.Title>

--- a/src/History/components/MyLecueBook/index.tsx
+++ b/src/History/components/MyLecueBook/index.tsx
@@ -29,7 +29,7 @@ function MyLecueBook(props: LecueBookProps) {
   const deleteFavoriteMutation = useDeleteFavorite('myLecueBook');
 
   const convertNoteCount = (noteNum: number) => {
-    setNoteCount(noteNum.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ','));
+    setNoteCount(noteNum.toLocaleString());
   };
 
   const handleClickBook = (bookUuid: string) => {

--- a/src/History/hooks/useDeleteMyBook.ts
+++ b/src/History/hooks/useDeleteMyBook.ts
@@ -1,16 +1,21 @@
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { deleteMyBook } from '../api/deleteMyBook';
 
 const useDeleteMyBook = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: (noteId: number) => {
       return deleteMyBook(noteId);
     },
     onError: () => navigate('/error'),
-    onSuccess: () => location.reload(),
+    onSuccess: () => {
+      queryClient.refetchQueries(['get-my-lecueBook'], {
+        exact: true,
+      });
+    },
   });
   return mutation;
 };

--- a/src/History/hooks/useDeleteMyBook.ts
+++ b/src/History/hooks/useDeleteMyBook.ts
@@ -17,7 +17,7 @@ const useDeleteMyBook = () => {
       });
     },
   });
-  return mutation;
+  return mutation.mutate;
 };
 
 export default useDeleteMyBook;

--- a/src/History/hooks/useGetMyBookList.ts
+++ b/src/History/hooks/useGetMyBookList.ts
@@ -6,7 +6,7 @@ import { getMyBookList } from '../api/getMyBookList';
 export default function useGetMyBookList() {
   const navigate = useNavigate();
   const { data: myBookList, isLoading } = useQuery(
-    ['useGetMyBookList'],
+    ['get-my-lecueBook'],
     () => getMyBookList(),
     {
       onError: () => {

--- a/src/components/common/LecueBook/index.tsx
+++ b/src/components/common/LecueBook/index.tsx
@@ -28,7 +28,7 @@ function LecueBook(props: LecueBookProps) {
 
   const navigate = useNavigate();
 
-  const MypageDeleteMutation = useDeleteFavorite('mypage');
+  const MypageDeleteMutation = useDeleteFavorite('favoriteBook');
   const HomeDeleteMutation = useDeleteFavorite('home');
 
   const handleClickFavoriteBtn = (

--- a/src/components/common/LecueBook/index.tsx
+++ b/src/components/common/LecueBook/index.tsx
@@ -28,16 +28,16 @@ function LecueBook(props: LecueBookProps) {
 
   const navigate = useNavigate();
 
-  const MypageDeleteMutation = useDeleteFavorite('favoriteBook');
-  const HomeDeleteMutation = useDeleteFavorite('home');
+  const deleteMypageMutation = useDeleteFavorite('favoriteBook');
+  const deleteHomeMutation = useDeleteFavorite('home');
 
   const handleClickFavoriteBtn = (
     bookId: number,
     deleteType: deleteType | undefined,
   ) => {
     deleteType === 'home'
-      ? HomeDeleteMutation.mutate(bookId)
-      : MypageDeleteMutation.mutate(bookId);
+      ? deleteHomeMutation.mutate(bookId)
+      : deleteMypageMutation.mutate(bookId);
   };
 
   const handleClickBook = (bookUuid: string) => {

--- a/src/components/common/LecueBook/index.tsx
+++ b/src/components/common/LecueBook/index.tsx
@@ -36,8 +36,8 @@ function LecueBook(props: LecueBookProps) {
     deleteType: deleteType | undefined,
   ) => {
     deleteType === 'home'
-      ? deleteHomeMutation.mutate(bookId)
-      : deleteMypageMutation.mutate(bookId);
+      ? deleteHomeMutation(bookId)
+      : deleteMypageMutation(bookId);
   };
 
   const handleClickBook = (bookUuid: string) => {

--- a/src/libs/hooks/useDeleteFavorite.ts
+++ b/src/libs/hooks/useDeleteFavorite.ts
@@ -12,13 +12,25 @@ const useDeleteFavorite = (state: string) => {
     },
     onError: () => navigate('/error'),
     onSuccess: () => {
-      state === 'home'
-        ? queryClient.refetchQueries(['get-favorite'], {
-            exact: true,
-          })
-        : queryClient.refetchQueries(['get-mypage-favorite'], {
+      switch (state) {
+        case 'home':
+          queryClient.refetchQueries(['get-favorite'], {
             exact: true,
           });
+          break;
+
+        case 'favoriteBook':
+          queryClient.refetchQueries(['get-mypage-favorite'], {
+            exact: true,
+          });
+          break;
+
+        case 'myLecueBook':
+          queryClient.refetchQueries(['get-my-lecueBook'], {
+            exact: true,
+          });
+          break;
+      }
     },
   });
   return mutation;

--- a/src/libs/hooks/useDeleteFavorite.ts
+++ b/src/libs/hooks/useDeleteFavorite.ts
@@ -7,31 +7,35 @@ const useDeleteFavorite = (state: string) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
+  const handleRefetchQueries = (state: string) => {
+    switch (state) {
+      case 'home':
+        queryClient.refetchQueries(['get-favorite'], {
+          exact: true,
+        });
+        break;
+
+      case 'favoriteBook':
+        queryClient.refetchQueries(['get-mypage-favorite'], {
+          exact: true,
+        });
+        break;
+
+      case 'myLecueBook':
+        queryClient.refetchQueries(['get-my-lecueBook'], {
+          exact: true,
+        });
+        break;
+    }
+  };
+
   const mutation = useMutation({
     mutationFn: (bookId: number) => {
       return deleteFavorite(bookId);
     },
     onError: () => navigate('/error'),
     onSuccess: () => {
-      switch (state) {
-        case 'home':
-          queryClient.refetchQueries(['get-favorite'], {
-            exact: true,
-          });
-          break;
-
-        case 'favoriteBook':
-          queryClient.refetchQueries(['get-mypage-favorite'], {
-            exact: true,
-          });
-          break;
-
-        case 'myLecueBook':
-          queryClient.refetchQueries(['get-my-lecueBook'], {
-            exact: true,
-          });
-          break;
-      }
+      handleRefetchQueries(state);
     },
   });
   return mutation.mutate;

--- a/src/libs/hooks/useDeleteFavorite.ts
+++ b/src/libs/hooks/useDeleteFavorite.ts
@@ -6,6 +6,7 @@ import deleteFavorite from '../api/deleteFavorite';
 const useDeleteFavorite = (state: string) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+
   const mutation = useMutation({
     mutationFn: (bookId: number) => {
       return deleteFavorite(bookId);
@@ -33,7 +34,7 @@ const useDeleteFavorite = (state: string) => {
       }
     },
   });
-  return mutation;
+  return mutation.mutate;
 };
 
 export default useDeleteFavorite;

--- a/src/libs/hooks/usePostFavorite.ts
+++ b/src/libs/hooks/usePostFavorite.ts
@@ -17,7 +17,7 @@ const usePostFavorite = () => {
       });
     },
   });
-  return mutation;
+  return mutation.mutate;
 };
 
 export default usePostFavorite;

--- a/src/libs/hooks/usePostFavorite.ts
+++ b/src/libs/hooks/usePostFavorite.ts
@@ -1,15 +1,21 @@
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 import postFavorite from '../api/postFavorite';
 
 const usePostFavorite = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: (bookId: number) => {
       return postFavorite(bookId);
     },
     onError: () => navigate('/error'),
+    onSuccess: () => {
+      queryClient.refetchQueries(['get-my-lecueBook'], {
+        exact: true,
+      });
+    },
   });
   return mutation;
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #315 

## ✅ 작업 내용

- [x] 내가 만든 레큐북, 즐겨찾기한 레큐북 싱크 안 맞음 이슈 해결

## 📸 스크린샷 / GIF / Link
https://github.com/Team-Lecue/Lecue-Client/assets/108219121/a0c7d243-c071-4526-8bad-7e2402b65a9f


## 📌 이슈 사항
즐겨찾기를 추가했을 때 -> 우선 즐겨찾기를 추가하는 경우는 (1) 마이페이지 - 내가 만든 레큐북에서 추가하는 경우 밖에 없어서 즐겨찾기 post hook에서 성공했을 때, getMtLecueBook api를 refetch하도록 변경해두었습니다! 나중에 레큐북 상세보기에서 즐겨찾기를 추가할 수 있게 된다면 요것도 case를 나눠주어야 할 듯 싶습니다..!

즐겨찾기를 해제했을 때 -> (1)홈에서 즐겨찾기를 해제한 경우 / (2)마이페이지 - 즐겨찾기한 레큐북에서 즐겨찾기를 해제한 경우 / (3) 마이페이지 - 내가 만든 레큐북에서 즐겨찾기를 해제한 경우, 요렇게 즐겨찾기를 해제하는 경우가 총 세가지가 있는데, 세 경우에 다시 호출해야하는 api가 달라서 switch - case 문으로 각각 필요한 api를 호출해주는 방식으로 변경했습니다!

```
onSuccess: () => {
      switch (state) {
        case 'home':
          queryClient.refetchQueries(['get-favorite'], {
            exact: true,
          });
          break;

        case 'favoriteBook':
          queryClient.refetchQueries(['get-mypage-favorite'], {
            exact: true,
          });
          break;

        case 'myLecueBook':
          queryClient.refetchQueries(['get-my-lecueBook'], {
            exact: true,
          });
          break;
      }
    },
```



## ✍ 궁금한 것
X