### PR TITLE
[ LecueNote ] 윈도우 상에서 노트 위에 스크롤 생기는 이슈 해결

### DIFF
--- a/src/Detail/components/BigLecueNote/BigLecueNote.style.ts
+++ b/src/Detail/components/BigLecueNote/BigLecueNote.style.ts
@@ -30,7 +30,7 @@ export const BigLecueNoteContentWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  overflow: hidden auto;
+  overflow-y: auto;
 
   width: 100%;
   height: 22.4rem;

--- a/src/Detail/components/BigLecueNote/BigLecueNote.style.ts
+++ b/src/Detail/components/BigLecueNote/BigLecueNote.style.ts
@@ -30,7 +30,7 @@ export const BigLecueNoteContentWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  overflow: scroll;
+  overflow: hidden auto;
 
   width: 100%;
   height: 22.4rem;

--- a/src/Detail/components/LecueNoteModal/LecueNoteModal.style.ts
+++ b/src/Detail/components/LecueNoteModal/LecueNoteModal.style.ts
@@ -55,7 +55,7 @@ export const LecueNoteModalContentWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  overflow: hidden auto;
+  overflow-y: auto;
 
   width: 100%;
   height: 23.4rem;

--- a/src/Detail/components/LecueNoteModal/LecueNoteModal.style.ts
+++ b/src/Detail/components/LecueNoteModal/LecueNoteModal.style.ts
@@ -55,7 +55,7 @@ export const LecueNoteModalContentWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  overflow: scroll;
+  overflow: hidden auto;
 
   width: 100%;
   height: 23.4rem;

--- a/src/LecueNote/components/ShowColorChart/ShowColorChart.style.ts
+++ b/src/LecueNote/components/ShowColorChart/ShowColorChart.style.ts
@@ -9,7 +9,7 @@ export const Wrapper = styled.div`
 
   padding: 0.2rem 0.1rem 1rem 0.3rem;
 
-  overflow-x: scroll;
+  overflow-x: auto;
 `;
 
 export const Input = styled.input`


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #314 

## ✅ 작업 내용

- [x] 선형뷰 - 큰 레큐 노트 위에 스크롤 생기는 이슈 해결
- [x] 노트 모달 - 지그재그 뷰에서 노트 클릭 시 화면에 뜨는 노트 모다레 스크롤 생기는 이슈 해결

## 📸 스크린샷 
### - 알바하는 곳 pc(윈도우)로 확인한 거라 캡처를 못해서 이렇게라도 찍어왔습니다 . .. 하하.. . ; 보기 불편하셨다면 죄송합니다 . .. ~

![KakaoTalk_Photo_2024-04-26-21-23-55 002](https://github.com/Team-Lecue/Lecue-Client/assets/80264647/435228e4-f42e-4aab-a766-7bf3488a1400)

![KakaoTalk_Photo_2024-04-26-21-23-55 001](https://github.com/Team-Lecue/Lecue-Client/assets/80264647/f97504cf-1238-442a-8e25-b3d14f91ac53)

## 📌 이슈 사항
- 노트 내용 부분이 `overflow: scroll`로 설정되어 있어서 내용이 넘치지 않아도 무조건 스크롤이 생기는 이슈였습니다!
- 처음엔 `overflow: auto`를 줘서 한 번에 스크롤을 다루려고 했는데요, 요렇게 했더니 내용이 길어지면 y축 뿐만 아니라 x축까지 스크롤이
  생겨버리더라구요!
- 저희는 가로 스크롤은 필요가 없기 때문에, `overflow: hidden auto`로 수정하여 x축 스크롤은 무조건 막고 
  내용물의 길이가 노트 높이보다 길어질 경우 y축에만 스크롤이 생기도록 했습니다 !!~
