### PR TITLE
[ Common ] 코드 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,26 @@
 import { Global, ThemeProvider } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
 import Router from './Router';
 import gStyle from './styles/GlobalStyles';
 import theme from './styles/theme';
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      suspense: true,
-      useErrorBoundary: true,
-      retry: 0,
-    },
-  },
-});
-
 function App() {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            suspense: true,
+            useErrorBoundary: true,
+            retry: 0,
+          },
+        },
+      }),
+  );
+
   const setScreenSize = () => {
     // vh 관련
     const vh = window.innerHeight * 0.01;

--- a/src/History/components/MyLecueBook/index.tsx
+++ b/src/History/components/MyLecueBook/index.tsx
@@ -26,7 +26,7 @@ function MyLecueBook(props: LecueBookProps) {
 
   const deleteBookMutation = useDeleteMyBook();
   const postFavoriteMutation = usePostFavorite();
-  const deleteFavoriteMutation = useDeleteFavorite('myLecueBook');
+  const deleteFavoriteMutation = useDeleteFavorite('lecueBook');
 
   const convertNoteCount = (noteNum: number) => {
     setNoteCount(noteNum.toLocaleString());

--- a/src/History/hooks/useDeleteMyBook.ts
+++ b/src/History/hooks/useDeleteMyBook.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
+import { QUERY_KEY } from '../../constants/queryKeys';
 import { deleteMyBook } from '../api/deleteMyBook';
 
 const useDeleteMyBook = () => {
@@ -12,7 +13,7 @@ const useDeleteMyBook = () => {
     },
     onError: () => navigate('/error'),
     onSuccess: () => {
-      queryClient.refetchQueries(['get-my-lecueBook'], {
+      queryClient.refetchQueries([QUERY_KEY.favorite.getLecueBookFavorite], {
         exact: true,
       });
     },

--- a/src/History/hooks/useDeleteMyBook.ts
+++ b/src/History/hooks/useDeleteMyBook.ts
@@ -13,7 +13,7 @@ const useDeleteMyBook = () => {
     },
     onError: () => navigate('/error'),
     onSuccess: () => {
-      queryClient.refetchQueries([QUERY_KEY.favorite.getLecueBookFavorite], {
+      queryClient.refetchQueries(QUERY_KEY.favorite.getLecueBookFavorite, {
         exact: true,
       });
     },

--- a/src/History/hooks/useGetMyBookList.ts
+++ b/src/History/hooks/useGetMyBookList.ts
@@ -7,7 +7,7 @@ import { getMyBookList } from '../api/getMyBookList';
 export default function useGetMyBookList() {
   const navigate = useNavigate();
   const { data: myBookList, isLoading } = useQuery(
-    [QUERY_KEY.favorite.getLecueBookFavorite],
+    QUERY_KEY.favorite.getLecueBookFavorite,
     () => getMyBookList(),
     {
       onError: () => {

--- a/src/History/hooks/useGetMyBookList.ts
+++ b/src/History/hooks/useGetMyBookList.ts
@@ -1,12 +1,13 @@
 import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
+import { QUERY_KEY } from '../../constants/queryKeys';
 import { getMyBookList } from '../api/getMyBookList';
 
 export default function useGetMyBookList() {
   const navigate = useNavigate();
   const { data: myBookList, isLoading } = useQuery(
-    ['get-my-lecueBook'],
+    [QUERY_KEY.favorite.getLecueBookFavorite],
     () => getMyBookList(),
     {
       onError: () => {

--- a/src/History/hooks/useGetMyFavorite.ts
+++ b/src/History/hooks/useGetMyFavorite.ts
@@ -7,7 +7,7 @@ import { getMyFavorite } from '../api/getMyFavorite';
 export default function useGetMyFavorite() {
   const navigate = useNavigate();
   const { data: myFavoriteList, isLoading } = useQuery(
-    [QUERY_KEY.favorite.getMypageFavorite],
+    QUERY_KEY.favorite.getMypageFavorite,
     () => getMyFavorite(),
     {
       onError: () => {

--- a/src/History/hooks/useGetMyFavorite.ts
+++ b/src/History/hooks/useGetMyFavorite.ts
@@ -1,12 +1,13 @@
 import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
+import { QUERY_KEY } from '../../constants/queryKeys';
 import { getMyFavorite } from '../api/getMyFavorite';
 
 export default function useGetMyFavorite() {
   const navigate = useNavigate();
   const { data: myFavoriteList, isLoading } = useQuery(
-    ['get-mypage-favorite'],
+    [QUERY_KEY.favorite.getMypageFavorite],
     () => getMyFavorite(),
     {
       onError: () => {

--- a/src/Home/constants/homeQueryKey.ts
+++ b/src/Home/constants/homeQueryKey.ts
@@ -1,0 +1,3 @@
+export const HOME_QUERY_KEY = {
+  getLecueBook: ['get-lecue-book'],
+};

--- a/src/Home/hooks/useGetLecueBook.ts
+++ b/src/Home/hooks/useGetLecueBook.ts
@@ -2,12 +2,13 @@ import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 import getLecueBook from '../api/getLecueBook';
+import { HOME_QUERY_KEY } from '../constants/homeQueryKey';
 
 const useGetLecueBook = () => {
   const navigate = useNavigate();
 
   const { isLoading: isLoadingLecueBook, data: lecueBook } = useQuery({
-    queryKey: ['get-lecue-book'],
+    queryKey: HOME_QUERY_KEY.getLecueBook,
     queryFn: () => getLecueBook(),
     onError: () => navigate('/error'),
     refetchOnWindowFocus: false,

--- a/src/LecueNote/hooks/usePostLecueNote.ts
+++ b/src/LecueNote/hooks/usePostLecueNote.ts
@@ -30,7 +30,7 @@ const usePostLecueNote = () => {
       navigate(`/lecue-book/${bookUuid}`);
     },
   });
-  return mutation;
+  return { postMutation: mutation.mutate, isLoading: mutation.isLoading };
 };
 
 export default usePostLecueNote;

--- a/src/LecueNote/hooks/usePutPresignedUrl.ts
+++ b/src/LecueNote/hooks/usePutPresignedUrl.ts
@@ -16,7 +16,7 @@ const usePutPresignedUrl = () => {
     },
     onError: () => navigate('/error'),
   });
-  return mutation;
+  return { putMutation: mutation.mutate, isLoading: mutation.isLoading };
 };
 
 export default usePutPresignedUrl;

--- a/src/LecueNote/page/LeceuNotePage/index.tsx
+++ b/src/LecueNote/page/LeceuNotePage/index.tsx
@@ -21,8 +21,11 @@ function LecueNotePage() {
   const MAX_LENGTH = 1000;
   const navigate = useNavigate();
   const location = useLocation();
-  const putMutation = usePutPresignedUrl();
-  const postMutation = usePostLecueNote();
+  const { putMutation } = usePutPresignedUrl();
+  const { postMutation } = usePostLecueNote();
+  const isMutationLoading =
+    usePutPresignedUrl().isLoading || usePostLecueNote().isLoading;
+
   const noteContents = sessionStorage.getItem('noteContents');
   const { bookId } = location.state || {};
 
@@ -84,14 +87,14 @@ function LecueNotePage() {
   const handleClickCompleteModal = async () => {
     if (lecueNoteState.imgToBinary) {
       if (lecueNoteState.imgToBinary.result && lecueNoteState.file) {
-        putMutation.mutate({
+        putMutation({
           presignedUrl: lecueNoteState.presignedUrl,
           binaryFile: lecueNoteState.imgToBinary.result,
           fileType: lecueNoteState.file.type,
         });
       }
     }
-    postMutation.mutate({
+    postMutation({
       contents: lecueNoteState.contents,
       color: lecueNoteState.textColor,
       fileName: lecueNoteState.filename,
@@ -103,7 +106,7 @@ function LecueNotePage() {
     sessionStorage.setItem('noteContents', '');
   };
 
-  return putMutation.isLoading || postMutation.isLoading ? (
+  return isMutationLoading ? (
     <LoadingPage />
   ) : (
     <S.Wrapper>

--- a/src/components/common/LecueBook/index.tsx
+++ b/src/components/common/LecueBook/index.tsx
@@ -28,7 +28,7 @@ function LecueBook(props: LecueBookProps) {
 
   const navigate = useNavigate();
 
-  const deleteMypageMutation = useDeleteFavorite('favoriteBook');
+  const deleteMypageMutation = useDeleteFavorite('mypage');
   const deleteHomeMutation = useDeleteFavorite('home');
 
   const handleClickFavoriteBtn = (

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,8 +1,8 @@
 export const QUERY_KEY = {
   favorite: {
-    getHomeFavorite: 'get-favorite',
+    getHomeFavorite: 'get-home-favorite',
     getMypageFavorite: 'get-mypage-favorite',
-    getLecueBookFavorite: 'get-my-lecueBook',
+    getLecueBookFavorite: 'get-lecueBook-favorite',
   },
   nickname: {
     getNickName: 'get-nickname',

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,10 +1,10 @@
 export const QUERY_KEY = {
   favorite: {
-    getHomeFavorite: 'get-home-favorite',
-    getMypageFavorite: 'get-mypage-favorite',
-    getLecueBookFavorite: 'get-lecueBook-favorite',
+    getHomeFavorite: ['get-home-favorite'],
+    getMypageFavorite: ['get-mypage-favorite'],
+    getLecueBookFavorite: ['get-lecueBook-favorite'],
   },
   nickname: {
-    getNickName: 'get-nickname',
+    getNickName: ['get-nickname'],
   },
 };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,8 +1,8 @@
 export const QUERY_KEY = {
   favorite: {
-    getFavoriteHome: 'get-favorite',
-    getFavoriteMypage: 'get-mypage-favorite',
-    getFavoriteLecueBook: 'get-my-lecueBook',
+    getHomeFavorite: 'get-favorite',
+    getMypageFavorite: 'get-mypage-favorite',
+    getLecueBookFavorite: 'get-my-lecueBook',
   },
   nickname: {
     getNickName: 'get-nickname',

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,0 +1,10 @@
+export const QUERY_KEY = {
+  favorite: {
+    getFavoriteHome: 'get-favorite',
+    getFavoriteMypage: 'get-mypage-favorite',
+    getFavoriteLecueBook: 'get-my-lecueBook',
+  },
+  nickname: {
+    getNickName: 'get-nickname',
+  },
+};

--- a/src/libs/hooks/useDeleteFavorite.ts
+++ b/src/libs/hooks/useDeleteFavorite.ts
@@ -4,25 +4,25 @@ import { useNavigate } from 'react-router-dom';
 import { QUERY_KEY } from '../../constants/queryKeys';
 import deleteFavorite from '../api/deleteFavorite';
 
-const useDeleteFavorite = (state: string) => {
+const useDeleteFavorite = (location: string) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const handleRefetchQueries = (state: string) => {
-    switch (state) {
+  const handleRefetchQueries = (location: string) => {
+    switch (location) {
       case 'home':
         queryClient.refetchQueries([QUERY_KEY.favorite.getFavoriteHome], {
           exact: true,
         });
         break;
 
-      case 'favoriteBook':
+      case 'mypage':
         queryClient.refetchQueries([QUERY_KEY.favorite.getFavoriteMypage], {
           exact: true,
         });
         break;
 
-      case 'myLecueBook':
+      case 'lecueBook':
         queryClient.refetchQueries([QUERY_KEY.favorite.getFavoriteLecueBook], {
           exact: true,
         });
@@ -36,7 +36,7 @@ const useDeleteFavorite = (state: string) => {
     },
     onError: () => navigate('/error'),
     onSuccess: () => {
-      handleRefetchQueries(state);
+      handleRefetchQueries(location);
     },
   });
   return mutation.mutate;

--- a/src/libs/hooks/useDeleteFavorite.ts
+++ b/src/libs/hooks/useDeleteFavorite.ts
@@ -11,19 +11,19 @@ const useDeleteFavorite = (location: string) => {
   const handleRefetchQueries = (location: string) => {
     switch (location) {
       case 'home':
-        queryClient.refetchQueries([QUERY_KEY.favorite.getFavoriteHome], {
+        queryClient.refetchQueries([QUERY_KEY.favorite.getHomeFavorite], {
           exact: true,
         });
         break;
 
       case 'mypage':
-        queryClient.refetchQueries([QUERY_KEY.favorite.getFavoriteMypage], {
+        queryClient.refetchQueries([QUERY_KEY.favorite.getMypageFavorite], {
           exact: true,
         });
         break;
 
       case 'lecueBook':
-        queryClient.refetchQueries([QUERY_KEY.favorite.getFavoriteLecueBook], {
+        queryClient.refetchQueries([QUERY_KEY.favorite.getLecueBookFavorite], {
           exact: true,
         });
         break;

--- a/src/libs/hooks/useDeleteFavorite.ts
+++ b/src/libs/hooks/useDeleteFavorite.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
+import { QUERY_KEY } from '../../constants/queryKeys';
 import deleteFavorite from '../api/deleteFavorite';
 
 const useDeleteFavorite = (state: string) => {
@@ -10,19 +11,19 @@ const useDeleteFavorite = (state: string) => {
   const handleRefetchQueries = (state: string) => {
     switch (state) {
       case 'home':
-        queryClient.refetchQueries(['get-favorite'], {
+        queryClient.refetchQueries([QUERY_KEY.favorite.getFavoriteHome], {
           exact: true,
         });
         break;
 
       case 'favoriteBook':
-        queryClient.refetchQueries(['get-mypage-favorite'], {
+        queryClient.refetchQueries([QUERY_KEY.favorite.getFavoriteMypage], {
           exact: true,
         });
         break;
 
       case 'myLecueBook':
-        queryClient.refetchQueries(['get-my-lecueBook'], {
+        queryClient.refetchQueries([QUERY_KEY.favorite.getFavoriteLecueBook], {
           exact: true,
         });
         break;

--- a/src/libs/hooks/useDeleteFavorite.ts
+++ b/src/libs/hooks/useDeleteFavorite.ts
@@ -11,19 +11,19 @@ const useDeleteFavorite = (location: string) => {
   const handleRefetchQueries = (location: string) => {
     switch (location) {
       case 'home':
-        queryClient.refetchQueries([QUERY_KEY.favorite.getHomeFavorite], {
+        queryClient.refetchQueries(QUERY_KEY.favorite.getHomeFavorite, {
           exact: true,
         });
         break;
 
       case 'mypage':
-        queryClient.refetchQueries([QUERY_KEY.favorite.getMypageFavorite], {
+        queryClient.refetchQueries(QUERY_KEY.favorite.getMypageFavorite, {
           exact: true,
         });
         break;
 
       case 'lecueBook':
-        queryClient.refetchQueries([QUERY_KEY.favorite.getLecueBookFavorite], {
+        queryClient.refetchQueries(QUERY_KEY.favorite.getLecueBookFavorite, {
           exact: true,
         });
         break;

--- a/src/libs/hooks/useGetFavorite.ts
+++ b/src/libs/hooks/useGetFavorite.ts
@@ -8,7 +8,7 @@ const useGetFavorite = () => {
   const navigate = useNavigate();
 
   const { isLoading: isLoadingFavorite, data: favorite } = useQuery({
-    queryKey: [QUERY_KEY.favorite.getHomeFavorite],
+    queryKey: QUERY_KEY.favorite.getHomeFavorite,
     queryFn: () => getFavorite(),
     onError: () => navigate('/error'),
     refetchOnWindowFocus: false,

--- a/src/libs/hooks/useGetFavorite.ts
+++ b/src/libs/hooks/useGetFavorite.ts
@@ -8,7 +8,7 @@ const useGetFavorite = () => {
   const navigate = useNavigate();
 
   const { isLoading: isLoadingFavorite, data: favorite } = useQuery({
-    queryKey: [QUERY_KEY.favorite.getFavoriteHome],
+    queryKey: [QUERY_KEY.favorite.getHomeFavorite],
     queryFn: () => getFavorite(),
     onError: () => navigate('/error'),
     refetchOnWindowFocus: false,

--- a/src/libs/hooks/useGetFavorite.ts
+++ b/src/libs/hooks/useGetFavorite.ts
@@ -1,13 +1,14 @@
 import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
+import { QUERY_KEY } from '../../constants/queryKeys';
 import getFavorite from '../api/getFavorite';
 
 const useGetFavorite = () => {
   const navigate = useNavigate();
 
   const { isLoading: isLoadingFavorite, data: favorite } = useQuery({
-    queryKey: ['get-favorite'],
+    queryKey: [QUERY_KEY.favorite.getFavoriteHome],
     queryFn: () => getFavorite(),
     onError: () => navigate('/error'),
     refetchOnWindowFocus: false,

--- a/src/libs/hooks/useGetMyNickname.ts
+++ b/src/libs/hooks/useGetMyNickname.ts
@@ -1,12 +1,13 @@
 import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
+import { QUERY_KEY } from '../../constants/queryKeys';
 import { getMyNickName } from '../api/getMyNickName';
 
 export default function useGetMyNickName() {
   const navigate = useNavigate();
   const { data: myNickName, isLoading } = useQuery(
-    ['useGetMyNickName'],
+    [QUERY_KEY.nickname.getNickName],
     () => getMyNickName(),
     {
       onError: () => {

--- a/src/libs/hooks/useGetMyNickname.ts
+++ b/src/libs/hooks/useGetMyNickname.ts
@@ -7,7 +7,7 @@ import { getMyNickName } from '../api/getMyNickName';
 export default function useGetMyNickName() {
   const navigate = useNavigate();
   const { data: myNickName, isLoading } = useQuery(
-    [QUERY_KEY.nickname.getNickName],
+    QUERY_KEY.nickname.getNickName,
     () => getMyNickName(),
     {
       onError: () => {

--- a/src/libs/hooks/usePostFavorite.ts
+++ b/src/libs/hooks/usePostFavorite.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
+import { QUERY_KEY } from '../../constants/queryKeys';
 import postFavorite from '../api/postFavorite';
 
 const usePostFavorite = () => {
@@ -12,7 +13,7 @@ const usePostFavorite = () => {
     },
     onError: () => navigate('/error'),
     onSuccess: () => {
-      queryClient.refetchQueries(['get-my-lecueBook'], {
+      queryClient.refetchQueries([QUERY_KEY.favorite.getLecueBookFavorite], {
         exact: true,
       });
     },

--- a/src/libs/hooks/usePostFavorite.ts
+++ b/src/libs/hooks/usePostFavorite.ts
@@ -13,7 +13,7 @@ const usePostFavorite = () => {
     },
     onError: () => navigate('/error'),
     onSuccess: () => {
-      queryClient.refetchQueries([QUERY_KEY.favorite.getLecueBookFavorite], {
+      queryClient.refetchQueries(QUERY_KEY.favorite.getLecueBookFavorite, {
         exact: true,
       });
     },


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #322 

## ✅ 작업 내용

- [x] queryClinet 선언 방식 수정
- [x] mutation 함수 선언 형식 변경
- [x] queryKey 상수화

## 📸 스크린샷 / GIF / Link
### 기존과 똑같이 동작하기 때문에 스크린샷 따로 첨부 안 했습니당 !!!

<br />

## 📌 이슈 사항
## 1. queryClient를 useState로 선언

### 🧪 기존 선언 방식: 컴포넌트 밖에 queryClient 선언

아무런 장치없이 컴포넌트 밖에 선언해줌 → 렌더링마다 새로운 리소스 생성

즉, 계속해서 리렌더링이 발생할 경우, QueryClient를 계속 다시 생성하는 것!

```jsx
const queryClient = new QueryClient({
  defaultOptions: {
    queries: {
      suspense: true,
      useErrorBoundary: true,
      retry: 0,
    },
  },
});

```

<br />

### 🧪 개선된 방식: 컴포넌트 내에 `useState`로  queryClient 선언

state는 setter를 호출할 경우에만 업데이트 → setter를 선언하지 않음으로써 setter를 호출하지 않음

즉, `참조 동일성`을 유지할 수 있음 !

컴포넌트 라이프사이클 당 한 번만 리소스를 생성함

###  ➡️ **이렇게 useState에 함수 형태가 아닌, `초기값 형태로 전달`한다면?**

코드는 문제없이 실행되지만, 해당 값이 사용되지 않거나 필요하지 않더라도 렌더링할 때마다 해당 코드를 실행하게 된다고 함 !

```jsx
const [queryClient] = useState(
    new QueryClient({
      defaultOptions: {
        queries: {
          suspense: true,
          useErrorBoundary: true,
          retry: 0,
        },
      },
    }),
);
```

###  ➡️ **최선책: `lazy initialization`**

**useState에 함수를 전달**하면 React는 초기 값이 필요할 때(컴포넌트가 처음 렌더링될 때)만 함수 호출

즉, initalState에 함수를 전달하면 **queryClient는 초기 한번만 생성되고, 이후에는 참조 동일성을 유지**하게 됨 !!

```tsx
const [queryClient] = useState(
  () =>
    new QueryClient({
      defaultOptions: {
        queries: {
          suspense: true,
          useErrorBoundary: true,
          retry: 0,
        },
      },
    }),
);
```

📚 참고자료: https://kentcdodds.com/blog/use-state-lazy-initialization-and-function-updates

<br />

###  **❓ 그럼 useMemo나 useRef를 사용해도 되지 않을까!??**

→ 둘 다 정상적으로 코드가 동작하기는 하지만, useMemo의 목적성에 맞지 않고 useRef의 current 사용으로 인해 코드가 길어지기도, null 값을 포함하기도 하기 때문에 적합하지 않다고 하네용 !

자세한 내용은 아래 아티클 참고해 보시길 ~~

📚 참고자료: https://jong6598.tistory.com/40

<br />

## 2. mutation 함수 선언 형식 변경

### 🧪 기존 방식: mutation 자체를  반환함

➡️ mutation 함수는 mutate를 반드시 수행함

➡️ mutate를 커스텀 훅에서 반환해주는 것이 mutation 함수의 역할에 더 적합하고 중복 코드도 줄이는 방법이라고 생각함

<br />

### 🧪 개선된 방식: mutation.mutate 반환

➡️ isLoading이 필요한 경우, 객체 타입으로 묶어 mutate와 isLoading을 한 번에 반환하도록 함

<br />

## 3. queryKey 상수화

### 🧪 기존 방식: 모든 커스텀 훅에서 queryKey를 각각 선언, 호출함

➡️ 유지보수에 매우 취약하고 가독성도 떨어진다고 판단함

<br />


### 🧪 개선된 방식: queryKey를 상수화함

➡️ 최적의 네이밍을 찾기 위해 여러 번 queryKey를 수정했는데 상수 파일만 만져주면 되기 때문에 매우 편하게 수정할 수 있었음 !

➡️ 제가 만들었던 컴포넌트 + 공통 컴포넌트에 있는 애들만 상수화 시켜놨습니다 !!
