### PR TITLE
[ Common ] Axios Instance 반복 생성 개선

### DIFF
--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -11,10 +11,9 @@ export const api = () => {
 
   const token = sessionStorage.getItem('token');
   if (token) {
-    const headerToken =
-      apiInstance.defaults.headers.common.Authorization?.toString();
+    const headerToken = apiInstance.defaults.headers.common.Authorization;
 
-    if (!headerToken || token !== headerToken.split(' ')[1]) {
+    if (!headerToken || token !== headerToken.toString().split(' ')[1]) {
       apiInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
     }
   }

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -1,12 +1,16 @@
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
+
+let apiInstance: AxiosInstance;
 
 export const api = () => {
-  const api = axios.create({
-    baseURL: import.meta.env.VITE_APP_BASE_URL,
-  });
-
   const token = sessionStorage.getItem('token');
-  api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
 
-  return api;
+  if (!apiInstance) {
+    apiInstance = axios.create({
+      baseURL: import.meta.env.VITE_APP_BASE_URL,
+    });
+  }
+  apiInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+
+  return apiInstance;
 };

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -1,21 +1,22 @@
 import axios, { AxiosInstance } from 'axios';
 
-let apiInstance: AxiosInstance;
+let apiInstance: AxiosInstance | null;
 
 export const api = () => {
-  const token = sessionStorage.getItem('token');
-
   if (!apiInstance) {
     apiInstance = axios.create({
       baseURL: import.meta.env.VITE_APP_BASE_URL,
     });
   }
 
-  const headerToken =
-    apiInstance.defaults.headers.common.Authorization?.toString();
+  const token = sessionStorage.getItem('token');
+  if (token) {
+    const headerToken =
+      apiInstance.defaults.headers.common.Authorization?.toString();
 
-  if (!headerToken || token !== headerToken.split(' ')[1]) {
-    apiInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+    if (!headerToken || token !== headerToken.split(' ')[1]) {
+      apiInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+    }
   }
 
   return apiInstance;

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -10,7 +10,13 @@ export const api = () => {
       baseURL: import.meta.env.VITE_APP_BASE_URL,
     });
   }
-  apiInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+
+  const headerToken =
+    apiInstance.defaults.headers.common.Authorization?.toString();
+
+  if (!headerToken || token !== headerToken.split(' ')[1]) {
+    apiInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+  }
 
   return apiInstance;
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #339 

## ✅ 작업 내용

- [x] axios instance가 이미 존재하는지 검사
- [x] 존재하지 않는다면 새로 create / 존재한다면 헤더에 실려있는 토큰과 현재 스토리지에 있는 토큰 값이 같은지 검사
- [x] 만약 헤더에 기본 토큰 값이 존재하지 않거나, 스토리지에 있는 토큰값과 같지 않은 경우 axios header default 재설정

## 📸 스크린샷 / GIF / Link
개선 이전 (콘솔창 봐보면 인스턴스가 반복해서 생성되고 있음!)

https://github.com/Team-Lecue/Lecue-Client/assets/108219121/d6a62d06-12d1-42d7-b34c-fed7d1a0901d




개선 이후(처음 인스턴스 생성 이후에 다시 생성되지 않음!)

https://github.com/Team-Lecue/Lecue-Client/assets/108219121/245cae91-4c2a-421f-b595-9b0148c13fd3



## 📌 이슈 사항
이전 코드

```
import axios from 'axios';

export const api = () => {
  const api = axios.create({
    baseURL: import.meta.env.VITE_APP_BASE_URL,
  });

  const token = sessionStorage.getItem('token');
  api.defaults.headers.common['Authorization'] = `Bearer ${token}`;

  return api;
};
```

개선된 코드
```
import axios, { AxiosInstance } from 'axios';

let apiInstance: AxiosInstance | null;

export const api = () => {
  if (!apiInstance) {
    apiInstance = axios.create({
      baseURL: import.meta.env.VITE_APP_BASE_URL,
    });
  }

  const token = sessionStorage.getItem('token');
  if (token) {
    const headerToken =
      apiInstance.defaults.headers.common.Authorization?.toString();

    if (!headerToken || token !== headerToken.split(' ')[1]) {
      apiInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
    }
  }

  return apiInstance;
};

```

`apiInstance`라는 변수를 하나 만들어서 존재 여부를 파악한 뒤, 존재하지 않을 때만 create하도록 조건을 만들었습니다. 다음으로는 header에 실려있는 token 값을 `headerToken` 이라는 변수에 받아와 존재하지 않거나, 스토리지에 저장되어 있는 토큰 값과 같지 않다면 다시 default header를 설정하도록 구현해보았습니다.

사실 토큰값은 로그인을 한번 하면 로그아웃을 하거나 창을 닫기 전까지는 변하지 않긴 합니다만 혹시모를 상황(존재하지 않는 토큰값을 헤더에 싣고 api를 호출하는 경우)에 대비해 토큰 일치 여부 확인 과정을 두었습니다. 또한, 스토리지에 토큰 값이 없다면 로그인상태가 아니기 때문에 header에 토큰 값을 실어 보내지 않아도 되어 로그인 여부를 먼저 확인하도록 구현했습니다.

`headerToken`의 타입 때문에 조금 시간이 걸렸었는데요, 콘솔에 headerToken의 type을 찍어보았을 때 분명 string이라고 나오는데, string에 사용할 수 있는 split 함수가 먹히지 않는 것이었습니다.. 그 이유는 즉슨 `axios.defaults.headers.common.~`으로 헤더에 실어진 값을 불러올 수 있지만, 불러온 값의 타입이 string이 아닌 `AxiosHeaderValue`로 인식된다는 것이었습니다.. 그래서 문자열 관련 매서드가 적용되지 않던 것이었지요. 그래서 결국 toString으로 타입을 변경하고, Bearer를 제외한 토큰 값만을 추출해 저장하였습니다..

## ✍ 궁금한 것
if문의 중첩.. 과연 괜찮은 것일까요? 이항연산자를 쓸까도 고민을 해보았는데 뭔가 코드가 한 눈에 안들어오는 느낌이랄까요..