### PR TITLE
[ BugFix ] 닉네임 설정 401 Error을 해결합니다.

### DIFF
--- a/src/Login/hooks/usePostLoginToken.ts
+++ b/src/Login/hooks/usePostLoginToken.ts
@@ -14,7 +14,7 @@ const usePostLoginToken = () => {
       const { tokenDto, nickname } = data;
 
       if (nickname === null) {
-        navigate('/register', { state: tokenDto.accessToken });
+        navigate('/register', { state: { tempToken: tokenDto.accessToken } });
       } else {
         sessionStorage.setItem('token', tokenDto.accessToken);
         sessionStorage.setItem('nickname', nickname);

--- a/src/Login/page/index.tsx
+++ b/src/Login/page/index.tsx
@@ -5,9 +5,6 @@ import LoginBtnContainer from '../components/LoginBtnContainer';
 import * as S from './Login.style';
 
 function Login() {
-  const ref = document.referrer;
-  sessionStorage.setItem('url', ref);
-
   return (
     <S.LoginWrapper>
       <Header />

--- a/src/Register/api/patchNickname.ts
+++ b/src/Register/api/patchNickname.ts
@@ -1,12 +1,13 @@
 import { api } from '../../libs/api';
 
-export const patchNickname = async (nickname: string) => {
+export const patchNickname = async (nickname: string, tempToken: string) => {
   const response = await api().patch(
     '/api/nickname',
     { nickname: nickname },
     {
       headers: {
         'Content-Type': 'application/json',
+        Authorization: `Bearer ${tempToken}`,
       },
     },
   );

--- a/src/Register/hooks/usePatchNickname.ts
+++ b/src/Register/hooks/usePatchNickname.ts
@@ -11,12 +11,13 @@ import {
 const usePatchNickname = (props: usePatchNicknameProps) => {
   const { handleSetIsValid, handleSetIsActive, nickname } = props;
   const { state } = useLocation();
+  const tempToken = state.tempToken;
 
   const navigate = useNavigate();
 
   const mutation = useMutation({
     mutationFn: async ({ nickname }: patchNicknameProps) => {
-      return await patchNickname(nickname);
+      return await patchNickname(nickname, tempToken);
     },
     onError: (err: AxiosError) => {
       const code = err.response?.status;
@@ -32,7 +33,7 @@ const usePatchNickname = (props: usePatchNicknameProps) => {
       }
     },
     onSuccess: () => {
-      sessionStorage.setItem('token', state);
+      sessionStorage.setItem('token', state.tempToken);
       sessionStorage.setItem('nickname', nickname);
       navigate('/', { state: { step: 1 } });
     },


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #348 

## ✅ 작업 내용

회원가입 후 닉네임 설정 시 발생하는 401 에러를 해결했어요.

`api.ts` 모듈 구현을 살펴보면 이유를 알 수 있는데, 
```ts
const token = sessionStorage.getItem('token');

if (token) {
  const headerToken = apiInstance.defaults.headers.common.Authorization;

  if (!headerToken || token !== headerToken.toString().split(' ')[1]) {
    apiInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
  }
}
```

sessionStorage 토큰이 존재할때만 토큰을 헤더에 심은 인스턴스를 반환하도록 설계되어있었어요.

저희 회원가입 플로우 상 카카오 인증을 완료한 후 닉네임을 입력하지 않으면 회원가입이 처리되지 않는 플로우로 구현되어 있었고, 회원가입이 완료되어야만 sessionStorage에 토큰을 저장하였어요.

하지만 닉네임 페이지에서는 회원가입이 아직 완료되지 않은 상태이기 때문에 sessionStorage에 토큰이 존재하지 않았고, 반환받은 api 모듈이 토큰을 header에 탑재하지 않은 상태였기 때문에 401 에러가 발생한 것이었어요.

그래서 저 경우에만 반환받은 api 인스턴스 header에 토큰을 직접 심어 Request하도록 수정했습니다.

```ts
export const patchNickname = async (nickname: string, tempToken: string) => {
  const response = await api().patch(
    '/api/nickname',
    { nickname: nickname },
    {
      headers: {
        'Content-Type': 'application/json',
        // 추가한 부분
        Authorization: `Bearer ${tempToken}`,
      },
    },
  );
  
  return { code: response.data.code };
};
```

하지만 이렇게 하면 요청 로직이 통일성을 가지지 않고, header에 토큰을 삽입하는 부분에 대한 책임이 분산되어 있어 더 좋은 방법을 고민하고 있어요. api 모듈 자체를 수정하는 방향으로 해결하는 것이 header에 토큰을 심는 부분에 있어 책임을 집중시키기 더 좋은 것 같다는 생각이 듭니다.
핫픽스 이슈라 지금은 일단 Merge하고 더 좋은 방법을 고민해보려고 하는데, 좋은 아이디어 있으면 언제든 알려주세요!!
 
추가적으로 state 변수에 token이 들어있었는데, 변수명만으로 어떤 값인지 파악이 모호할 수 있어 state.tempToken에서 token을 관리하도록 수정하였습니다.