### PR TITLE
[ Hotfix ] 레큐 북 제작 시 발생하는 400 에러 해결

### DIFF
--- a/src/Target/page/TargetPage/index.tsx
+++ b/src/Target/page/TargetPage/index.tsx
@@ -66,7 +66,7 @@ function TargetPage() {
     navigate('/select-book', {
       state: { presignedFileName: presignedFileName, name: name },
     });
-  }, []);
+  }, [name, fileData, presignedFileName]);
 
   const handleEscapeModal = useCallback(() => {
     setEscapeModal(true);


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #350 

## ✅ 작업 내용

- [x] 레큐 북 제작 시 발생하는 400 에러 해결

## 📸 스크린샷 / GIF / Link
![image](https://github.com/user-attachments/assets/fc8fcca2-3ee0-4c12-96e6-d979230f82f9)

## 📌 이슈 사항
레큐 북을 제작할 때 400에러가 발생하는 이슈가 있었고, 에러 메시지를 확인해보니 아래와 같이 최애 이름은 1자 이상 15자 이하로 지정하라는 내용이 있었어요. 또한, response를 자세히 보니 최애 이름과 레큐 북 사진 부분에 아무런 데이터도 들어가지 않는 모습을 확인할 수 있었어요.
![image](https://github.com/user-attachments/assets/70d61a50-6b57-4e0c-8f65-f4f89f6c3ccd)

최애 이름과 레큐북 사진을 입력하는 페이지에서 콘솔로 해당 내용을 확인해보니, 최애 이름과 레큐북 사진 데이터가 잘 들어오고 있었어요.
그런데 완료 버튼을 눌렀을 때 실행되는 함수 내부에서는 콘솔에 아무런 내용도 찍히지 않더라구요.
해당 함수를 다시 살펴보니 useCallback으로 정의되어 있었는데 의존성이 빈 배열로 되어있어서, 최애 이름과 레큐북 사진 데이터가 들어오더라도 함수 내부에서는 변경된 내용이 입력되지 않고 있었어요.

의존성에 `name, fileData, presignedFileName`을 추가해주어 문제를 해결했어요.