### PR TITLE
feat: 레큐북 뷰 초기 진입 시 붉은 박스가 나타났다 사라지는 이슈를 해결합니다.

### DIFF
--- a/src/Detail/components/LecueNoteListContainer/index.tsx
+++ b/src/Detail/components/LecueNoteListContainer/index.tsx
@@ -29,7 +29,7 @@ interface LecueNoteListContainerProps {
   noteList: NoteType[];
   postedStickerList: postedStickerType[];
   isEditable: boolean;
-  setEditableStateFalse: () => void;
+  setEditableStateTrue: () => void;
   bookUuid: string;
   bookId: number;
 }
@@ -41,7 +41,7 @@ function LecueNoteListContainer(props: LecueNoteListContainerProps) {
     noteList,
     postedStickerList,
     isEditable,
-    setEditableStateFalse,
+    setEditableStateTrue,
     bookUuid,
     bookId,
   } = props;
@@ -85,8 +85,8 @@ function LecueNoteListContainer(props: LecueNoteListContainerProps) {
         postedStickerId: stickerId,
         stickerImage: stickerImage,
       }));
-    } else {
-      setEditableStateFalse();
+
+      setEditableStateTrue();
     }
   }, [location.state, isEditable]);
 

--- a/src/Detail/page/DetailPage/index.tsx
+++ b/src/Detail/page/DetailPage/index.tsx
@@ -22,8 +22,8 @@ function DetailPage() {
     : useGetBookDetail(bookUuid);
   const postMutation = usePostStickerState(bookUuid);
 
-  const setEditableStateFalse = () => {
-    setIsEditable(false);
+  const setEditableStateTrue = () => {
+    setIsEditable(true);
   };
 
   return isLoading || postMutation.isLoading ? (
@@ -39,7 +39,7 @@ function DetailPage() {
             bookId={bookDetail.bookId}
             bookUuid={bookUuid}
             isEditable={isEditable}
-            setEditableStateFalse={setEditableStateFalse}
+            setEditableStateTrue={setEditableStateTrue}
             noteNum={bookDetail.noteNum}
             backgroundColor={bookDetail.bookBackgroundColor}
             noteList={bookDetail.noteList}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #352 

## ✅ 작업 내용
레큐북 뷰 초기 진입 시 붉은 박스가 나타났다 사라지는 이슈를 해결했어요.

원인은 `isEditable` 상태관리 때문이었어요.

기존에는 컴포넌트가 mount되면서 `isEditable`의 초기 상태가 `true`로 설정되고,

```tsx
const [isEditable, setIsEditable] = useState(true);
```

useEffect문 안에 들어가서 스티커 부착 모드가 아니면 `setEditableStateFalse()`으로 isEditable state를 false로 set하고 있었어요.

```tsx
useEffect(() => {
    if (location.state) {
      const { stickerId, stickerImage } = location.state.sticker;

      window.scrollTo(0, savedScrollPosition);

      setStickerState((prev) => ({
        ...prev,
        postedStickerId: stickerId,
        stickerImage: stickerImage,
      }));
    } else {
      setEditableStateFalse();
    }
  }, [location.state, isEditable]);
```

또 붉은 테두리는 스티커 컴포넌트의 영역을 표시하는 border인데, isEditable이 true면 영역을 표시하도록 로직이 짜여 있었어요.

useEffect는 초기 Mount 이후에 로직을 실행하므로, useEffect 로직이 돌아 isEditable이 false로 세팅되기 전 찰나에 border가 표시되었다가 사라지는 것이 원인이었어요. border가 잠깐 표시될 찰나에는 스티커가 선택되지 않았을 것이고, 결국 스티커는 없고 스티커 부착 영역만 렌더되게 되어 붉은 빈 박스가 떴던 것이었어요.

이를 해결하기 위해 초기 상태를 false로 세팅했어요. false로 세팅하지 않으면 깜빡임 문제를 근본적으로 해결할 수 없기 때문이에요.

```tsx
const [isEditable, setIsEditable] = useState(false);
```

그 후, useEffect 내부에서 true인지 false인지 검사를 하는데, 초기값이 false이므로, 스티커 부착 모드이면 true로 set하는 방향으로 로직을 수정했어요.

```tsx
useEffect(() => {
    if (location.state) {
      const { stickerId, stickerImage } = location.state.sticker;

      window.scrollTo(0, savedScrollPosition);

      setStickerState((prev) => ({
        ...prev,
        postedStickerId: stickerId,
        stickerImage: stickerImage,
      }));
      setEditableStateTrue();
    } 
  }, [location.state, isEditable]);
```

이렇게 하면 초기 붉은 박스가 나타났다 사라지는 이슈 해결이 가능해요.

@eunbeann
물론 은빈이가 작성한 로직이라 초기 상태가 true인 이유가 있을지도 모른다고 생각해서 은빈이가 한 번 로직 확인해주면 좋을 것 같아용 :)

## 📸 스크린샷 / GIF / Link



https://github.com/user-attachments/assets/d8c018f2-bd41-4881-8217-d58015cb711c

