### PR TITLE
[ Hotfix ] 레큐북 뷰 초기 진입 시 스티커 부착 뷰가 렌더링되는 이슈를 수정합니다.

### DIFF
--- a/src/Detail/page/DetailPage/index.tsx
+++ b/src/Detail/page/DetailPage/index.tsx
@@ -12,7 +12,7 @@ import useGetBookDetailLogin from '../../hooks/useGetBookDetailLogin';
 import * as S from './DetailPage.style';
 
 function DetailPage() {
-  const [isEditable, setIsEditable] = useState(true);
+  const [isEditable, setIsEditable] = useState(false);
 
   const isLogin = sessionStorage.getItem('token');
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #355

## ✅ 작업 내용

레큐북 뷰 초기 진입 시 스티커 부착 뷰가 렌더링되는 이슈를 수정했어요.

#353 에서 state의 초기값을 false로 세팅했다고 했는데, 변경사항이 적용이 안 되었는지 true인 상태로 머지가 되어버렸더라구요.....
빠르게 수정했습니다!!!!!

@doyn511 QA 고마워요 🚀🚀
