### PR TITLE
[ Home/ Detail ] 레큐 북 즐겨찾기를 여러 번 눌러도 한 번만 추가되게 구현

### DIFF
--- a/src/Detail/components/BookInfoBox/index.tsx
+++ b/src/Detail/components/BookInfoBox/index.tsx
@@ -33,11 +33,22 @@ function BookInfoBox({
 }: BookInfoBoxProps) {
   const isLogin = sessionStorage.getItem('token');
 
-  const postFavoriteMutation = usePostFavorite('lecueBookDetail', bookUuid);
-  const deleteFavoriteMutation = useDeleteFavorite('lecueBookDetail', bookUuid);
+  const { postFavoriteMutation, isPostLoading } = usePostFavorite(
+    'lecueBookDetail',
+    bookUuid,
+  );
+  const { deleteFavoriteMutation, isDeleteLoading } = useDeleteFavorite(
+    'lecueBookDetail',
+    bookUuid,
+  );
+
+  const isLoading = isPostLoading || isDeleteLoading;
 
   const handleFavoriteBtn = () => {
-    isFavorite ? deleteFavoriteMutation(bookId) : postFavoriteMutation(bookId);
+    if (!isLoading)
+      isFavorite
+        ? deleteFavoriteMutation(bookId)
+        : postFavoriteMutation(bookId);
   };
 
   return (

--- a/src/libs/hooks/useDeleteFavorite.ts
+++ b/src/libs/hooks/useDeleteFavorite.ts
@@ -48,7 +48,10 @@ const useDeleteFavorite = (state: string, bookUuid?: string) => {
       handleRefetchQueries(state, bookUuid);
     },
   });
-  return mutation.mutate;
+  return {
+    deleteFavoriteMutation: mutation.mutate,
+    isDeleteLoading: mutation.isLoading,
+  };
 };
 
 export default useDeleteFavorite;

--- a/src/libs/hooks/usePostFavorite.ts
+++ b/src/libs/hooks/usePostFavorite.ts
@@ -36,7 +36,10 @@ const usePostFavorite = (location: string, bookUuid?: string) => {
       handleRefetchQueries(location, bookUuid);
     },
   });
-  return mutation.mutate;
+  return {
+    postFavoriteMutation: mutation.mutate,
+    isPostLoading: mutation.isLoading,
+  };
 };
 
 export default usePostFavorite;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #358 

## ✅ 작업 내용

- [x] 레큐 북 즐겨찾기를 여러 번 눌러도 한 번만 추가되게 구현

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/21c282a8-831d-4ded-9d2b-29a321ac792d


## 📌 이슈 사항
레큐 북의 상세 페이지에서 즐겨찾기를 빠르게 연속으로 클릭하면, 클릭한 횟수만큼 즐겨찾기 POST 요청이 전송됐어요. 이로 인해 동일한 레큐 북이 여러 번 즐겨찾기에 추가되었고, 홈 페이지에서 즐겨찾기된 레큐 북을 불러오는 과정에서 에러가 발생했어요.

처음에는 이 문제를 해결하기 위해서 debounce를 도입할까 고민했지만, react-query의 isLoading을 활용해서 간단히 해결했어요.
react-query는 통신 상태를 나타내는 다양한 옵션을 제공하는데, 그중 isLoading을 활용해서 즐겨찾기 추가/ 삭제 처리 완료 여부를 확인했어요. 즐겨찾기 추가/ 삭제 처리 중이 아닐 때만 즐겨찾기 아이콘 클릭 함수가 활성화되도록 하여 중복 요청을 방지했어요.